### PR TITLE
Code Review: Convert hello-world plugin example to use API (#9534)

### DIFF
--- a/Source/Document.js
+++ b/Source/Document.js
@@ -104,4 +104,14 @@ export class Document extends WrappedObject {
       if (layer)
         return new Layer(layer, this);
     }
+
+    /**
+      Center the view of the document window on a given layer.
+
+      @param {Layer} layer The layer to center on.
+      */
+
+    centerOnLayer(layer) {
+      this._object.currentView().centerRect_(layer._object.rect())
+    }
 }

--- a/Source/Text.js
+++ b/Source/Text.js
@@ -103,4 +103,14 @@ export class Text extends Layer {
         this._object.textBehaviour = BCTextBehaviourFlexibleWidth
       }
     }
+
+    /**
+      Adjust the frame of the layer to fit its contents.
+    */
+
+    resizeToFitContents() {
+      this._object.adjustFrameToFit()
+    }
+
+
 }


### PR DESCRIPTION
Code review for Convert hello-world plugin example to use API (#9534):

> Wherever possible, our plugins should use the JS API, so that when people copy them, they also use the API.


Connect to BohemianCoding/Sketch#9534.