### PR TITLE
Code Review: Improve wrapping in JS API (#10163)

### DIFF
--- a/Source/Application.js
+++ b/Source/Application.js
@@ -351,16 +351,17 @@ export class Application extends WrappedObject {
 
                 /** @test {Application#wrapObject} */
                 testWrapObject(tester) {
+                  var classesToTest = [MSLayerGroup, MSPage, MSArtboardGroup, MSShapeGroup, MSBitmapLayer, MSTextLayer]
                   var mappings = tester.application.wrapperMappings()
-                  for (var mapping in mappings) {
-                    print(mapping)
+                  for (var index in classesToTest) {
+                    var classToTest = classesToTest[index]
                     var frame = NSMakeRect(0, 0, 100, 100)
-                    var object = mapping.alloc().initWithFrame(frame)
+                    var object = classToTest.alloc().initWithFrame(frame)
                     var mockDocument = {}
                     var wrapped = tester.application.wrapObject(object, mockDocument)
                     tester.assertEqual(wrapped._object, object)
                     tester.assertEqual(wrapped._document, mockDocument)
-                    tester.assertEqual(wrapped._prototype, mappings[mapping]._prototype)
+                    tester.assertEqual(wrapped.class, mappings[classToTest].class)
                   }
                 }
             }

--- a/Source/Application.js
+++ b/Source/Application.js
@@ -45,24 +45,6 @@ export class Application extends WrappedObject {
          @type {dictionary}
          */
         this._metadata = MSApplicationMetadata.metadata()
-
-
-        /**
-         This is a slightly clumsy way to pass related classes into Layer
-         without setting up a circular dependency between classes (eg Layer imports Artboard which imports Layer...)
-         there has to be a better way to do this...
-
-         @type {dictionary}
-         */
-
-        this.factory = {
-            "Group" : Group,
-            "Page" : Page,
-            "Artboard" : Artboard,
-            "Shape" : Shape,
-            "Image" : Image,
-            "Text" : Text
-        }
     }
 
     /**
@@ -132,7 +114,7 @@ export class Application extends WrappedObject {
      */
 
     settingForKey(key) {
-        return NSUserDefaults.standardUserDefaults()._objectForKey_(key);
+        return NSUserDefaults.standardUserDefaults().objectForKey_(key);
     }
 
     /**
@@ -303,6 +285,37 @@ export class Application extends WrappedObject {
     }
 
     /**
+     Return a wrapped version of a Sketch object.
+     We don't know about *all* Sketch object types, but
+     for some we will return a special subclass.
+     The fallback position is just to return an instance of WrappedObject.
+
+     @param {object} sketchObject The underlying sketch object that we're wrapping.
+     @param {Document} inDocument The wrapped document that this object is part of.
+     @return {WrappedObject} A javascript object (subclass of WrappedObject), which represents the Sketch object we were given.
+    */
+
+    wrapObject(sketchObject, inDocument) {
+      var mapping = {
+        MSLayerGroup : Group,
+        MSPage : Page,
+        MSArtboardGroup : Artboard,
+        MSShapeGroup : Shape,
+        MSBitmapLayer : Image,
+        MSTextLayer : Text
+      }
+
+      var jsClass = mapping[sketchObject.class()]
+      if (!jsClass) {
+        print("no map for " + sketchObject.class())
+        print(mapping)
+        jsClass = WrappedObject
+      }
+
+      return new jsClass(sketchObject, inDocument)
+    }
+
+    /**
      Return a list of tests to run for this class.
 
      We could do some fancy introspection here to derive the tests from
@@ -355,9 +368,9 @@ export class Application extends WrappedObject {
                 "WrappedObject" : WrappedObject.tests()
             }
         }
-        
+
         var tester = new Tester(this);
         return tester.runUnitTests(tests);
     }
-    
+
 }

--- a/Source/Application.js
+++ b/Source/Application.js
@@ -337,6 +337,16 @@ export class Application extends WrappedObject {
                 "test app version" : function(tester) {
                     tester.assertEqual(tester.application.version, "1.0");
                 }
+
+                /** @test {Application#wrapObject} */
+                "test wrap object" : function(tester) {
+                  var frame = NSMakeRect(0, 0, 100, 100)
+                  var object = MSLayerGroup().alloc().initWithFrame(frame)
+                  var mockDocument = {}
+                  var wrapped = tester.application.wrapObject(object, mockDocument)
+                  tester.assertEqual(wrapped._object, object)
+                  tester.assertEqual(wrapped._document, mockDocument)
+                }
             }
         };
     }

--- a/Source/Application.js
+++ b/Source/Application.js
@@ -285,6 +285,25 @@ export class Application extends WrappedObject {
     }
 
     /**
+     Return a lookup table of known mappings between Sketch model classes
+     and our JS API wrapper classes.
+
+     @return {dictionary} A dictionary with keys for the Sketch Model classes, and values for the corresponding API wrapper classes.
+     */
+
+    wrapperMappings() {
+      var mappings = {
+        MSLayerGroup : Group,
+        MSPage : Page,
+        MSArtboardGroup : Artboard,
+        MSShapeGroup : Shape,
+        MSBitmapLayer : Image,
+        MSTextLayer : Text
+      }
+      return mappings
+    }
+
+    /**
      Return a wrapped version of a Sketch object.
      We don't know about *all* Sketch object types, but
      for some we will return a special subclass.
@@ -296,19 +315,11 @@ export class Application extends WrappedObject {
     */
 
     wrapObject(sketchObject, inDocument) {
-      var mapping = {
-        MSLayerGroup : Group,
-        MSPage : Page,
-        MSArtboardGroup : Artboard,
-        MSShapeGroup : Shape,
-        MSBitmapLayer : Image,
-        MSTextLayer : Text
-      }
+      var mapping = this.wrapperMappings()
 
       var jsClass = mapping[sketchObject.class()]
       if (!jsClass) {
-        print("no map for " + sketchObject.class())
-        print(mapping)
+        print("no mapped wrapper for " + sketchObject.class())
         jsClass = WrappedObject
       }
 
@@ -329,23 +340,28 @@ export class Application extends WrappedObject {
             /** @test {Application} */
             "tests" : {
                 /** @test {Application#api_version} */
-                "test api version" : function(tester) {
-                    tester.assertEqual(tester.application.api_version, "1.1");
+                testAPIVersion(tester) {
+                    tester.assertEqual(tester.application.api_version, "1.1")
                 },
 
                 /** @test {Application#version} */
-                "test app version" : function(tester) {
-                    tester.assertEqual(tester.application.version, "1.0");
-                }
+                testApplicationVersion(tester) {
+                    tester.assertEqual(tester.application.version, "1.0")
+                },
 
                 /** @test {Application#wrapObject} */
-                "test wrap object" : function(tester) {
-                  var frame = NSMakeRect(0, 0, 100, 100)
-                  var object = MSLayerGroup().alloc().initWithFrame(frame)
-                  var mockDocument = {}
-                  var wrapped = tester.application.wrapObject(object, mockDocument)
-                  tester.assertEqual(wrapped._object, object)
-                  tester.assertEqual(wrapped._document, mockDocument)
+                testWrapObject(tester) {
+                  var mappings = tester.application.wrapperMappings()
+                  for (var mapping in mappings) {
+                    print(mapping)
+                    var frame = NSMakeRect(0, 0, 100, 100)
+                    var object = mapping.alloc().initWithFrame(frame)
+                    var mockDocument = {}
+                    var wrapped = tester.application.wrapObject(object, mockDocument)
+                    tester.assertEqual(wrapped._object, object)
+                    tester.assertEqual(wrapped._document, mockDocument)
+                    tester.assertEqual(wrapped._prototype, mappings[mapping]._prototype)
+                  }
                 }
             }
         };

--- a/Source/Document.js
+++ b/Source/Document.js
@@ -83,7 +83,7 @@ export class Document extends WrappedObject {
     */
 
     layerWithID(layer_id) {
-      var layer = this._object._documentData().layerWithID_(layer_id);
+      var layer = this._object.documentData().layerWithID_(layer_id);
       if (layer)
         return new Layer(layer, this);
     }
@@ -100,7 +100,7 @@ export class Document extends WrappedObject {
       // That might not always be true though, which is why the JS API splits
       // them into separate functions.
 
-      var layer = this._object._documentData().layerWithID_(layer_name);
+      var layer = this._object.documentData().layerWithID_(layer_name);
       if (layer)
         return new Layer(layer, this);
     }

--- a/Source/Layer.js
+++ b/Source/Layer.js
@@ -81,7 +81,7 @@ export class Layer extends WrappedObject {
     */
 
     duplicate() {
-      return new Layer(this._object.duplicate(), this._document);
+      return self._document.wrapObject(this._object.duplicate());
     }
 
     /**
@@ -162,8 +162,7 @@ export class Layer extends WrappedObject {
         layer.addLayers_(NSArray.arrayWithObject_(newLayer))
 
         // make a Javascript wrapper object for the new layer
-        var wrapperToMake = this._document._application.factory[wrapper]
-        var wrapper = new wrapperToMake(newLayer, this._document)
+        var wrapper = this._document.wrapObject(newLayer)
 
         // apply properties, via the wrapper
         for (var p in properties) {
@@ -300,7 +299,8 @@ export class Layer extends WrappedObject {
     iterate(block) {
       var loop = this._object().layers().objectEnumerator();
       while (item = loop.nextObject()) {
-        block(new Layer(item, this._document));
+        var layer = self._document.wrapObject(item)
+        block(layer);
       }
     }
 

--- a/Source/Selection.js
+++ b/Source/Selection.js
@@ -78,7 +78,8 @@ export class Selection extends WrappedObject {
       var loop = layers.objectEnumerator();
       var item;
       while (item = loop.nextObject()) {
-        block(new Layer(item));
+        var layer = this._object._application.wrapObject(item, this._object)
+        block(layer);
       }
     }
 


### PR DESCRIPTION
Code review for Improve wrapping in JS API (#10163):

> At the moment we've got a function to wrap Sketch objects in JS objects, but it only works if you explicitly tell it what kind of Sketch object you've got. 
> 
> This is fine when you *know*, eg when asking to make a new layer, you know what kind of layer you want. It's not so good though when doing something like iterating a collection of layers, where all you know is that they are layers, but what you actually need is to make a wrapper for each, and have it be a `Text` object for `MSTextLayer`, and `Image` object for `MSBitmapLayer`, and so on.
> 
> This needs to be improved, so that we can give any of the major layer types to `Application` and get back a wrapper object of the right type. 


Connect to BohemianCoding/Sketch#10163.