### PR TITLE
Change the output directory for the built SketchAPI.js file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 Source/generated/
+build/
+Output/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 Source/generated/
 build/
-Output/
+**/SketchAPI.js
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Once that's ready, you can run
 gulp
 ```
 
-to compile the library. It will be saved in `../SketchPluginManager/Source/SketchAPI.js` (you can tweak the output path in `gulpfile.js`)
+to compile the library. It will be saved in `Output/SketchAPI.js`.
 
 To have Sketch use the .js file you just built, you can run this:
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,17 @@ npm install -g gulp
 npm install
 ```
 
-Once that's ready, you can run
+Once that's ready, you can run:
 
 ```
 gulp
 ```
 
-to compile the library. It will be saved in `Output/SketchAPI.js`.
+to compile the library. By default, it will be saved to `../SketchPluginManager/Source/SketchAPI.js`. You can specify your own output path by using the `--output` argument:
+
+```
+gulp --output ~/Development/SketchAPI/Output/SketchAPI.js
+```
 
 To have Sketch use the .js file you just built, you can run this:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ gulp
 to compile the library. By default, it will be saved to `../SketchPluginManager/Source/SketchAPI.js`. You can specify your own output path by using the `--output` argument:
 
 ```
-gulp --output ~/Development/SketchAPI/Output/SketchAPI.js
+gulp --output Output/SketchAPI.js
 ```
 
 To have Sketch use the .js file you just built, you can run this:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,7 @@ gulp.task('deploy', function (callback) {
 
   var scriptPath = path.join(__dirname, 'build', 'api.js');
   var headerPath = path.join(__dirname, 'header.js');
-  var deploymentPath = path.join(__dirname, '..', 'SketchPluginManager', 'Source', 'SketchAPI.js');
+  var deploymentPath = path.join(__dirname, 'Output', 'SketchAPI.js');
 
   async.parallel({
     runtime: function (callback) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ var spawn       = require("gulp-spawn");
 var minimist    = require('minimist');
 
 var options = minimist(process.argv.slice(2), {
-  string: 'output', default: { output: path.join(__dirname, '..', 'SketchPluginManager', 'Source', 'SketchAPI.js') }
+  string: 'output', default: { output: path.join('..', 'SketchPluginManager', 'Source', 'SketchAPI.js') }
 });
 
 gulp.task('clean', function () {
@@ -33,6 +33,10 @@ gulp.task('deploy', function (callback) {
 
   var scriptPath = path.join(__dirname, 'build', 'api.js');
   var headerPath = path.join(__dirname, 'header.js');
+  var deploymentPath = options.output;
+  if (!path.isAbsolute(deploymentPath)) {
+    deploymentPath = path.join(__dirname, deploymentPath);
+  }
 
   async.parallel({
     runtime: function (callback) {
@@ -40,7 +44,7 @@ gulp.task('deploy', function (callback) {
       var header = fs.readFileSync(headerPath, 'utf8');
       script = [header, script].join("");
 
-      fse.outputFile(options.output, script, callback);
+      fse.outputFile(deploymentPath, script, callback);
     }
   }, function (err, data) {
     callback(null);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,11 @@ var path        = require('path');
 var runSequence = require('run-sequence');
 var source      = require('vinyl-source-stream');
 var spawn       = require("gulp-spawn");
+var minimist    = require('minimist');
+
+var options = minimist(process.argv.slice(2), {
+  string: 'output', default: { output: path.join(__dirname, '..', 'SketchPluginManager', 'Source', 'SketchAPI.js') }
+});
 
 gulp.task('clean', function () {
   return del(['build']);
@@ -28,7 +33,6 @@ gulp.task('deploy', function (callback) {
 
   var scriptPath = path.join(__dirname, 'build', 'api.js');
   var headerPath = path.join(__dirname, 'header.js');
-  var deploymentPath = path.join(__dirname, 'Output', 'SketchAPI.js');
 
   async.parallel({
     runtime: function (callback) {
@@ -36,7 +40,7 @@ gulp.task('deploy', function (callback) {
       var header = fs.readFileSync(headerPath, 'utf8');
       script = [header, script].join("");
 
-      fse.outputFile(deploymentPath, script, callback);
+      fse.outputFile(options.output, script, callback);
     }
   }, function (err, data) {
     callback(null);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "gulp-spawn": "^0.3.0",
     "lodash": "^4.2.1",
     "run-sequence": "^1.1.5",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "minimist": "^1.2.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
I changed the output directory to be within the project repository in `Output/SketchAPI.js` so that everything related to this project is contained within this folder. I also added `Output/` to the `.gitignore` file so the resulting built file won't be committed.

There may be a better name other than `Output` for this folder, the main thing I wanted to accomplish with this PR was for the resulting js file to be within the project folder to keep everything together and not mess with the developer's folder structure outside of the project folder.