### PR TITLE
Expose layers, and mark nativeLayers as 'private'.

### DIFF
--- a/Source/Group.js
+++ b/Source/Group.js
@@ -46,6 +46,18 @@ export class Group extends Layer {
   @return {dictionary} A dictionary containing the tests to run. Each key is the name of a test, each value is a function which takes a Tester instance.
   */
 
+  /**
+    Return the layers in the group.
+
+    @return {array} The selected layers.
+    */
+  get layers() {
+      var layers = [];
+      this.iterate(function(layer) {
+          layers.push(layer);
+      });  
+      return layers;
+  } 
 
   /**
   Perform a function for every sub-layer inside this one.

--- a/Source/Selection.js
+++ b/Source/Selection.js
@@ -43,7 +43,7 @@ export class Selection extends WrappedObject {
       */
     get layers() {
         var layers = [];
-        selection.iterate(function(layer) {
+        this.iterate(function(layer) {
             layers.push(layer);
         });  
         return layers;

--- a/Source/Selection.js
+++ b/Source/Selection.js
@@ -29,13 +29,25 @@ export class Selection extends WrappedObject {
     /**
       Return the native Sketch layers in the selection.
 
-      @return {array} The selected layers.
+      @return {array} The selected native Sketch layers.
       */
 
-    get nativeLayers() {
-      var layers = this._object.selectedLayers().layers();
-      return layers
+    get _nativeLayers() {
+      return this._object.selectedLayers().layers();
     }
+
+    /**
+      Return the layers in the selection.
+
+      @return {array} The selected layers.
+      */
+    get layers() {
+        var layers = [];
+        selection.iterate(function(layer) {
+            layers.push(layer);
+        });  
+        return layers;
+    }    
 
 
     /**
@@ -45,7 +57,7 @@ export class Selection extends WrappedObject {
       */
 
     get length() {
-      return this.nativeLayers.count()
+      return this._nativeLayers.count()
     }
 
     
@@ -56,7 +68,7 @@ export class Selection extends WrappedObject {
     */
 
     get isEmpty() {
-        return (this.nativeLayers.count() == 0);
+        return (this._nativeLayers.count() == 0);
     }
 
 
@@ -67,7 +79,7 @@ export class Selection extends WrappedObject {
     */
 
     iterateThenClear(block) {
-      var layers = this.nativeLayers
+      var layers = this._nativeLayers
       this.clear();
       this._page._document.iterateWithNativeLayers(layers, null, block);
     }
@@ -80,7 +92,7 @@ export class Selection extends WrappedObject {
     */
 
     iterateWithFilterThenClear(filter, block) {
-      var layers = this.nativeLayers
+      var layers = this._nativeLayers
       this.clear();
       this._page._document.iterateWithNativeLayers(layers, filter, block);
     }
@@ -92,7 +104,7 @@ export class Selection extends WrappedObject {
     */
 
     iterate(block) {
-      this._page._document.iterateWithNativeLayers(this.nativeLayers, null, block);
+      this._page._document.iterateWithNativeLayers(this._nativeLayers, null, block);
     }
 
     /**
@@ -103,7 +115,7 @@ export class Selection extends WrappedObject {
     */
 
     iterateWithFilter(filter, block) {
-      this._page._document.iterateWithNativeLayers(this.nativeLayers, filter, block);
+      this._page._document.iterateWithNativeLayers(this._nativeLayers, filter, block);
     }
 
 


### PR DESCRIPTION
As I worked on my own plugins using this new api, I encountered the need to get an array of the currently selected layers. I also think this follows the conventions laid out by others parts of the api where `_` denotes the underlying 'private' Sketch object, like `_object`.
