### PR TITLE
Replace getters with type class property

### DIFF
--- a/Source/Artboard.js
+++ b/Source/Artboard.js
@@ -8,6 +8,7 @@
 // ## Imports
 
 import { Layer } from './Layer.js'
+import { ARTBOARD } from './Constants'
 
 /**
     A Sketch artboard.
@@ -24,18 +25,6 @@ export class Artboard extends Layer {
 
     constructor(artboard, document) {
       super(artboard, document)
+      this.type = ARTBOARD
     }
-
-    /**
-        Is this an artboard?
-
-        All Layer objects respond to this method, but only Artboard objects return true.
-
-        @return true for instances of Artboard, false for any other layer type.
-    */
-
-    get isArtboard() {
-      return true;
-    }
-
 }

--- a/Source/Constants.js
+++ b/Source/Constants.js
@@ -1,0 +1,6 @@
+export const ARTBOARD = 1;
+export const GROUP = 2;
+export const IMAGE = 3;
+export const PAGE = 4;
+export const SHAPE = 5;
+export const TEXT = 6;

--- a/Source/Group.js
+++ b/Source/Group.js
@@ -8,14 +8,11 @@
 // ## Imports
 
 import { Layer } from './Layer.js'
+import { GROUP } from './Constants'
 
 export class Group extends Layer {
     constructor(group, document) {
       super(group, document)
+      this.type = GROUP
     }
-
-    is_group() {
-      return true;
-    }
-
 }

--- a/Source/Image.js
+++ b/Source/Image.js
@@ -8,14 +8,12 @@
 // ## Imports
 
 import { Layer } from './Layer.js'
+import { IMAGE } from './Constants'
 
 export class Image extends Layer {
   constructor(page, document) {
     super(page, document)
-  }
-
-  get isImage() {
-    return true;
+    this.type = IMAGE;
   }
 
   set imageURL(url) {

--- a/Source/Layer.js
+++ b/Source/Layer.js
@@ -38,13 +38,6 @@ export class Layer extends WrappedObject {
       return new Layer(this.object.duplicate(), this.document);
     }
 
-    get isPage() { return false; }
-    get isArtboard() { return false; }
-    get isGroup() { return false; }
-    get isText() { return false; }
-    get isShape() { return false; }
-    get isImage() { return false; }
-
     addWrappedLayerWithProperties(newLayer, properties, wrapper) {
       if (newLayer) {
         // add the Sketch object to this layer

--- a/Source/Page.js
+++ b/Source/Page.js
@@ -8,14 +8,12 @@
 // ## Imports
 
 import { Layer } from './Layer.js'
+import { PAGE } from './Constants'
 
 export class Page extends Layer {
   constructor(page, document) {
     super(page)
     this.document = document
-  }
-
-  get isPage() {
-    return true;
+    this.type = PAGE
   }
 }

--- a/Source/Shape.js
+++ b/Source/Shape.js
@@ -8,14 +8,11 @@
 // ## Imports
 
 import { Layer } from './Layer.js'
+import { SHAPE } from './Constants'
 
 export class Shape extends Layer {
     constructor(shape, document) {
       super(shape, document)
+      this.type = SHAPE
     }
-
-    get isShape() {
-      return true;
-    }
-
 }

--- a/Source/Text.js
+++ b/Source/Text.js
@@ -8,6 +8,7 @@
 // ## Imports
 
 import { Layer } from './Layer.js'
+import { TEXT } from './Constants';
 
 // ## Constants
 
@@ -17,10 +18,7 @@ const BCTextBehaviourFixedWidth = 1
 export class Text extends Layer {
     constructor(text, document) {
       super(text, document)
-    }
-
-    get isText() {
-      return true
+      this.type = TEXT
     }
 
     // Get/set the text of the layer.


### PR DESCRIPTION
This replaces all the `is*` getters with a type property allowing easier type checking.

This allows the user to write neat and more generic code like this:

```js
import { IMAGE } from './Constants';

const elements = [];
elements.push(new Page(page, document));
elements.push(new Image(page, document));

elements.forEach(el => { 
  if (el.type === IMAGE) {
    // do something
  }
});
```