### PR TITLE
Cleanup es6 import statements

### DIFF
--- a/Source/API.js
+++ b/Source/API.js
@@ -4,32 +4,13 @@
 // All code (C) 2016 Bohemian Coding.
 // ********************************
 
-import Application from './Application'
-
-
-/**
-    Return a function that captures the context.
-    When called, this function will initialise the API
-    and return an Application object that provides access
-    to all API functions.
-
-    We do it like this to defer having to perform a lot
-    of setup until context.api() is actually called -- thus
-    scripts which don't call it at all suffer minimal overhead.
- */
-
-function SketchAPIWithCapturedContext(context) {
-    return (function() {
-
-      // The Application object effectively *is* the api -- all other
-      // functions and objects can be accessed via it.
-
-      return new Application(context)
-    });
-}
-
-// HACK: expose the SketchAPIWithCapturedContext function globally
-// I suspect that there's a better way to do this, but I've
-// not yet figured it out.
-
-__globals.SketchAPIWithCapturedContext = SketchAPIWithCapturedContext
+export { default as Application } from './Application'
+export { default as WrappedObject } from './WrappedObject'
+export { default as Document } from './Document'
+export { default as Rectangle } from './Rectangle'
+export { default as Group } from './Group'
+export { default as Text } from './Text'
+export { default as Image } from './Image'
+export { default as Shape } from './Shape'
+export { default as Artboard } from './Artboard'
+export { default as Page } from './Page'

--- a/Source/API.js
+++ b/Source/API.js
@@ -4,7 +4,7 @@
 // All code (C) 2016 Bohemian Coding.
 // ********************************
 
-import { Application } from './Application.js'
+import Application from './Application'
 
 
 /**

--- a/Source/Application.js
+++ b/Source/Application.js
@@ -7,15 +7,15 @@
 
 // ## Imports
 
-import { WrappedObject } from './WrappedObject.js'
-import { Document } from './Document.js'
-import { Rectangle } from './Rectangle.js'
-import { Group } from './Group.js'
-import { Text } from './Text.js'
-import { Image } from './Image.js'
-import { Shape } from './Shape.js'
-import { Artboard } from './Artboard.js'
-import { Page } from './Page.js'
+import WrappedObject from './WrappedObject'
+import Document from './Document'
+import Rectangle from './Rectangle'
+import Group from './Group'
+import Text from './Text'
+import Image from './Image'
+import Shape from './Shape'
+import Artboard from './Artboard'
+import Page from './Page'
 
 /**
     Gives you access to Sketch, and provides access to:
@@ -25,7 +25,7 @@ import { Page } from './Page.js'
     - access to the running plugin, it's resources and settings
 */
 
-export class Application extends WrappedObject {
+export default class Application extends WrappedObject {
 
     /**
         Construct a new Application object.

--- a/Source/Artboard.js
+++ b/Source/Artboard.js
@@ -7,13 +7,13 @@
 
 // ## Imports
 
-import { Layer } from './Layer.js'
+import Layer from './Layer'
 
 /**
     A Sketch artboard.
 */
 
-export class Artboard extends Layer {
+export default class Artboard extends Layer {
 
     /**
         Make a new artboard.

--- a/Source/Document.js
+++ b/Source/Document.js
@@ -5,16 +5,16 @@
 // All code (C) 2016 Bohemian Coding.
 // ********************************
 
-import { WrappedObject } from './WrappedObject.js'
-import { Layer } from './Layer.js'
-import { Page } from './Page.js'
-import { Selection } from './Selection.js'
+import WrappedObject from './WrappedObject'
+import Layer from './Layer'
+import Page from './Page'
+import Selection from './Selection'
 
 /**
     A Sketch document.
 */
 
-export class Document extends WrappedObject {
+export default class Document extends WrappedObject {
     /**
         Make a new document object.
 

--- a/Source/Group.js
+++ b/Source/Group.js
@@ -7,9 +7,9 @@
 
 // ## Imports
 
-import { Layer } from './Layer.js'
+import Layer from './Layer'
 
-export class Group extends Layer {
+export default class Group extends Layer {
     constructor(group, document) {
       super(group, document)
     }

--- a/Source/Image.js
+++ b/Source/Image.js
@@ -7,9 +7,9 @@
 
 // ## Imports
 
-import { Layer } from './Layer.js'
+import Layer from './Layer'
 
-export class Image extends Layer {
+export default class Image extends Layer {
   constructor(page, document) {
     super(page, document)
   }

--- a/Source/Layer.js
+++ b/Source/Layer.js
@@ -7,10 +7,10 @@
 
 // ## Imports
 
-import { WrappedObject } from './WrappedObject.js'
-import { Rectangle } from './Rectangle.js'
+import WrappedObject from './WrappedObject'
+import Rectangle from './Rectangle'
 
-export class Layer extends WrappedObject {
+export default class Layer extends WrappedObject {
     constructor(layer, document) {
       super(layer)
       this.document = document

--- a/Source/Page.js
+++ b/Source/Page.js
@@ -7,9 +7,9 @@
 
 // ## Imports
 
-import { Layer } from './Layer.js'
+import Layer from './Layer'
 
-export class Page extends Layer {
+export default class Page extends Layer {
   constructor(page, document) {
     super(page)
     this.document = document

--- a/Source/Rectangle.js
+++ b/Source/Rectangle.js
@@ -7,7 +7,7 @@
 
 // ## Imports
 
-export class Rectangle {
+export default class Rectangle {
   constructor(x, y, w, h) {
     this.x = x
     this.y = y

--- a/Source/Selection.js
+++ b/Source/Selection.js
@@ -5,15 +5,15 @@
 // All code (C) 2016 Bohemian Coding.
 // ********************************
 
-import { WrappedObject } from './WrappedObject.js'
-import { Layer } from './Layer.js'
+import WrappedObject from './WrappedObject'
+import Layer from './Layer'
 
 
 /**
     Represents the layers that the user has selected.
 */
 
-export class Selection extends WrappedObject {
+export default class Selection extends WrappedObject {
     constructor(document) {
       super(document)
     }

--- a/Source/Shape.js
+++ b/Source/Shape.js
@@ -7,9 +7,9 @@
 
 // ## Imports
 
-import { Layer } from './Layer.js'
+import Layer from './Layer'
 
-export class Shape extends Layer {
+export default class Shape extends Layer {
     constructor(shape, document) {
       super(shape, document)
     }

--- a/Source/Text.js
+++ b/Source/Text.js
@@ -7,14 +7,14 @@
 
 // ## Imports
 
-import { Layer } from './Layer.js'
+import Layer from './Layer'
 
 // ## Constants
 
 const BCTextBehaviourFlexibleWidth = 0
 const BCTextBehaviourFixedWidth = 1
 
-export class Text extends Layer {
+export default class Text extends Layer {
     constructor(text, document) {
       super(text, document)
     }

--- a/Source/WrappedObject.js
+++ b/Source/WrappedObject.js
@@ -8,7 +8,7 @@
 // Base class for all objects that
 // wrap Sketch classes.
 
-export class WrappedObject {
+export default class WrappedObject {
     constructor(object) {
       this.object = object
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,6 +59,7 @@ gulp.task('bundle', function () {
   var bundler = browserify({
     entries: ['./Source/API.js'],
     extensions: ['.js'],
+    standalone: 'sketch-api',
     debug: false
   });
 

--- a/header.js
+++ b/header.js
@@ -53,4 +53,3 @@ sketch.alert("Title", "message");
 
 */
 
-var __globals = this;


### PR DESCRIPTION
- Remove unneeded filename extensions in import declarations
- use default exports for files which only contain one class
- Fix bundle not exporting anything at all

This PR is based on #39 which should be merged before this one. 