### PR TITLE
Code Review: "MSImageData.alloc().initWithImage_convertColorSpace is not a function" in SketchAPI (#15219)

### DIFF
--- a/Source/Image.js
+++ b/Source/Image.js
@@ -44,7 +44,7 @@ export class Image extends Layer {
 
   set imageURL(url) {
     var image = NSImage.alloc().initWithContentsOfURL_(url)
-    var imageData = MSImageData.alloc().initWithImage_convertColorSpace_(image, true)
+    var imageData = MSImageData.alloc().initWithImage(image)
     this._object.setImage_(imageData)
   }
 


### PR DESCRIPTION
Code review for “"MSImageData.alloc().initWithImage_convertColorSpace is not a function" in SketchAPI” (#15219):

Connect to BohemianCoding/Sketch#15219.