### PR TITLE
:bug: fix layer document

### DIFF
--- a/docs/api/Layer.md
+++ b/docs/api/Layer.md
@@ -4,7 +4,7 @@ order: 202
 section: components
 ---
 
-A Sketch layer. This component is not exposed, it is only returned when create a new layer instance from component with extends from `Layer`, e.g., [Group](#group). And you can use some instance methods of the returned layer.
+A Sketch layer. This component is not exposed, it is only returned when create a new layer instance from component which extends from `Layer`, e.g., [Group](#group). And you can use some instance methods of the returned layer.
 
 | Properties | type                    | Description                                                                                     |
 | ---------- | ----------------------- | ----------------------------------------------------------------------------------------------- |

--- a/docs/api/Layer.md
+++ b/docs/api/Layer.md
@@ -4,7 +4,7 @@ order: 202
 section: components
 ---
 
-A Sketch layer. This component is not exposed, it is only returned when create a new layer instance from component which extends from `Layer`, e.g., [Group](#group). And you can use some instance methods of the returned layer.
+A Sketch layer. This is the base class for most of the Sketch components and defines methods to manipulate them..
 
 | Properties | type                    | Description                                                                                     |
 | ---------- | ----------------------- | ----------------------------------------------------------------------------------------------- |

--- a/docs/api/Layer.md
+++ b/docs/api/Layer.md
@@ -4,11 +4,7 @@ order: 202
 section: components
 ---
 
-```javascript
-var Layer = require('sketch/dom').Layer
-```
-
-A Sketch layer.
+A Sketch layer. This component is not exposed, it is only returned when create a new layer instance from component with extends from `Layer`, e.g., [Group](#group). And you can use some instance methods of the returned layer.
 
 | Properties | type                    | Description                                                                                     |
 | ---------- | ----------------------- | ----------------------------------------------------------------------------------------------- |
@@ -18,19 +14,6 @@ A Sketch layer.
 | frame      | [Rectangle](#rectangle) | The frame of the Layer. This is given in coordinates that are local to the parent of the layer. |
 | selected   | Boolean                 | If the layer is selected.                                                                       |
 | flow       | [Flow](#flow)           | The prototyping action associated with the layer.                                               |
-
-## Creating a new layer
-
-```javascript
-new Layer()
-```
-
-```javascript
-var layer = new Layer({
-  name: 'my name',
-  parent: existingGroup,
-})
-```
 
 ## duplicate
 


### PR DESCRIPTION
the `Layer` component is not exposed to the api and we can not create a new layer by calling `new Layer()`