### PR TITLE
Bug/set override value

### DIFF
--- a/Source/dom/components/Override.js
+++ b/Source/dom/components/Override.js
@@ -51,6 +51,9 @@ Override.define('value', {
     if (this.property === 'image') {
       this.__symbolInstance.setOverrideValue(this, ImageData.from(value))
       return
+    } else if (this.property === 'stringValue') {
+      this.__symbolInstance.setOverrideValue(this, String(value))
+      return
     }
     this.__symbolInstance.setOverrideValue(this, value)
   },

--- a/Source/dom/components/Override.js
+++ b/Source/dom/components/Override.js
@@ -48,13 +48,6 @@ Override.define('value', {
   },
   set(value) {
     // __symbolInstance is set when building the Override
-    if (this.property === 'image') {
-      this.__symbolInstance.setOverrideValue(this, ImageData.from(value))
-      return
-    } else if (this.property === 'stringValue') {
-      this.__symbolInstance.setOverrideValue(this, String(value))
-      return
-    }
     this.__symbolInstance.setOverrideValue(this, value)
   },
 })

--- a/Source/dom/components/SymbolInstance.js
+++ b/Source/dom/components/SymbolInstance.js
@@ -37,19 +37,18 @@ export class SymbolInstance extends Layer {
   }
 
   setOverrideValue(override, value) {
-    const { property } = wrapObject(override)
-    const overridePoint = wrapObject(override).sketchObject.overridePoint()
-    if (property === 'image') {
+    const wrappedOverride = wrapObject(override)
+    const overridePoint = wrappedOverride.sketchObject.overridePoint()
+    if (wrappedOverride.property === 'image') {
       this._object.setValue_forOverridePoint(
         ImageData.from(value),
         overridePoint
       )
-      return this
-    } else if (property === 'stringValue') {
+    } else if (wrappedOverride.property === 'stringValue') {
       this._object.setValue_forOverridePoint(String(value), overridePoint)
-      return this
+    } else {
+      this._object.setValue_forOverridePoint(value, overridePoint)
     }
-    this._object.setValue_forOverridePoint(value, overridePoint)
     return this
   }
 }

--- a/Source/dom/components/SymbolInstance.js
+++ b/Source/dom/components/SymbolInstance.js
@@ -6,6 +6,7 @@ import { Factory } from '../Factory'
 import { wrapObject } from '../wrapNativeObject'
 import { toArray } from '../utils'
 import { Override } from './Override'
+import { ImageData } from './ImageData'
 
 /**
  * A Sketch symbol instance.
@@ -36,10 +37,19 @@ export class SymbolInstance extends Layer {
   }
 
   setOverrideValue(override, value) {
-    this._object.setValue_forOverridePoint(
-      value,
-      wrapObject(override).sketchObject.overridePoint()
-    )
+    const { property } = wrapObject(override)
+    const overridePoint = wrapObject(override).sketchObject.overridePoint()
+    if (property === 'image') {
+      this._object.setValue_forOverridePoint(
+        ImageData.from(value),
+        overridePoint
+      )
+      return this
+    } else if (property === 'stringValue') {
+      this._object.setValue_forOverridePoint(String(value), overridePoint)
+      return this
+    }
+    this._object.setValue_forOverridePoint(value, overridePoint)
     return this
   }
 }


### PR DESCRIPTION
there is two issues when set override value:

1. If I set a non string value to override whose `property` is `stringValue`(a `number` type value for example), Sketch just crash before we can get any error message.

1. If someone set the value by `setOverrideValue` which is implemented in `SymbolInstance`, the checks defined in `Override` will not work