### PR TITLE
Fix bug in Rectangle copying functionality

### DIFF
--- a/Source/dom/Rectangle.js
+++ b/Source/dom/Rectangle.js
@@ -13,7 +13,7 @@ export class Rectangle {
    */
   constructor(x, y, width, height) {
     // if the argument is object
-    if (x && x.x) {
+    if (typeof x === "object" && typeof x.x === "number") {
       this.x = parseFloat(x.x)
       this.y = parseFloat(x.y)
       this.width = parseFloat(x.width)

--- a/Source/dom/__tests__/Rectangle.test.js
+++ b/Source/dom/__tests__/Rectangle.test.js
@@ -19,6 +19,14 @@ test('should create a rectangle using an object', () => {
   expect(r.height).toBe(4)
 })
 
+test('should create a rectangle using an object when x === 0 (#133)', () => {
+  const r = new Rectangle({ x: 0, y: 2, width: 3, height: 4 })
+  expect(r.x).toBe(0)
+  expect(r.y).toBe(2)
+  expect(r.width).toBe(3)
+  expect(r.height).toBe(4)
+})
+
 test('should create a rectangle using another rectangle', () => {
   const r2 = new Rectangle({ x: 1, y: 2, width: 3, height: 4 })
   const r = new Rectangle(r2)


### PR DESCRIPTION
The former code failed to correctly copy source rectangles whose `x` == `0`, returning a Rectangle with `{ x: nan... }`. It might also be worthwhile to put some checks in place to ensure `NaN` is never possible as the values for any of the rectangle properties.