### PR TITLE
Fix onOpenDocument example function

### DIFF
--- a/_guides/actions.md
+++ b/_guides/actions.md
@@ -38,7 +38,7 @@ We're telling our plugin that we want to run the `onOpenDocument` function when 
 
 ```js
 export function onOpenDocument(context) {
-  context.document.showMessage('Document Opened')
+  context.actionContext.document.showMessage("Document Opened")
 }
 ```
 


### PR DESCRIPTION
Message toast wasn’t showing up because the dictionary structure of **context** is slightly different.