### PR TITLE
fix svgo_export example

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,6 +21,7 @@ globals:
   MSTextLayer: false
   MSShapeGroup: false
   NSArray: false
+  NSTask: false
   NSMakePoint: false
   CGRectMake: false
   MSArtboardGroup: false

--- a/examples/svgo-export/package.json
+++ b/examples/svgo-export/package.json
@@ -3,16 +3,14 @@
   "description": "Uses SVGO to compress exported SVG assets",
   "author": "Ale Muñoz <ale@sketchapp.com>",
   "version": "0.1.0",
+  "license" : "SEE LICENSE IN README.md",
   "engines": {
     "sketch": ">=3.0"
   },
   "skpm": {
     "name": "SVGO Export",
     "manifest": "src/manifest.json",
-    "main": "plugin.sketchplugin",
-    "assets": [
-      "assets/**/*"
-    ]
+    "main": "plugin.sketchplugin"
   },
   "scripts": {
     "build": "skpm-build",
@@ -21,7 +19,8 @@
     "postinstall": "cd assets && npm i && cd .. && npm run build && skpm-link"
   },
   "devDependencies": {
-    "@skpm/builder": "^0.4.0"
+    "@skpm/builder": "^0.4.0",
+    "copy-webpack-plugin": "^4.5.1"
   },
   "dependencies": {
     "sketch-utils": "^0.1.2"

--- a/examples/svgo-export/src/manifest.json
+++ b/examples/svgo-export/src/manifest.json
@@ -9,7 +9,8 @@
       "script": "./svgo-export.js",
       "handlers": {
         "actions": {
-          "ExportSlices": "onExportSlices"
+          "ExportSlices": "onExportSlices",
+          "Startup" : "onStartup"    
         }
       }
     }

--- a/examples/svgo-export/src/svgo-export.js
+++ b/examples/svgo-export/src/svgo-export.js
@@ -7,6 +7,12 @@
 // it was installed using `npm install --save sketch-utils`
 const toArray = require('sketch-utils/to-array')
 
+// when the plugin starts, ensure we can run the svgo binary
+export function onStartup(context){
+  var svgoPath = getSVGOPath(context)
+  ensureSVGOExecutable(svgoPath)
+}
+
 // ### Main Handler
 // This is the handler we defined on `manifest.json` for the event (`ExportSlices.finish`). It will be passed a `context` object as a parameter.
 // `context.actionContext` is the action that has been triggered, and it looks like this:
@@ -29,7 +35,7 @@ export function onExportSlices(context) {
     .filter(currentExport => currentExport.request.format() == 'svg')
     .map(
       currentExport =>
-        String(currentExport.path.stringByDeletingLastPathComponent()) // When we find an asset in SVG format, then we'll want to compress the folder it's been exported to.
+        String(currentExport.path) // When we find an asset in SVG format, then we'll want to compress it
     )
 
   if (pathsToCompress.length > 0) {
@@ -37,17 +43,8 @@ export function onExportSlices(context) {
     const paths = uniqueArray(pathsToCompress)
     let success = true
 
-    // Now we run through each one...
-    paths.forEach(path => {
-      log(`Compressing SVG files in ${path}`)
-      // ...doing the export, and log the result to the console
-      if (optimizeFolderWithSVGO(context, path)) {
-        log('✅ compression ok')
-      } else {
-        log('❌ compression error')
-        success = false
-      }
-    })
+    var svgoPath = getSVGOPath(context)
+    success = optimizeFilesWithSVGO(svgoPath, paths)
 
     // Finally, make some noise to let the user know that we're done, and if everything went according to plan.
     //
@@ -61,28 +58,41 @@ export function onExportSlices(context) {
 // Utility function to run a command line command with a set of arguments.
 function runCommand(command, args) {
   const task = NSTask.alloc().init()
-  task.launchPath = command
+  task.setLaunchPath_(command)
   task.arguments = args
   task.launch()
   task.waitUntilExit()
   return task.terminationStatus() == 0
 }
 
-// This is the function where we call out to svgo to do the heavy lifting (i.e: compress all SVG files in a given folder).
-//
-// svgo is installed installed in the Resources folder of our plugin so we need to get it from there.
+function getSVGOPath(context){
+  return context.plugin.urlForResourceNamed('node_modules/svgo/bin/svgo').path()
+}
+
+function ensureSVGOExecutable(svgoPath){
+  return runCommand('/bin/chmod', ['+x', svgoPath])
+}
+
+// This is the function where we call out to svgo to do the heavy lifting (i.e: compress all SVG files).
 //
 // The SVGO options are based on our experience working with Sketch's exported SVGs, and to the best of our knowledge
 // they shouldn't effect the rendering of your assets, just reduce their size.
-function optimizeFolderWithSVGO(context, folderPath) {
-  const pathToSVGO = context.plugin.urlForResourceNamed(
-    'node_modules/.bin/svgo'
-  )
-  return runCommand('/bin/bash', [
-    '-l',
-    '-c',
-    `${pathToSVGO} --folder='${folderPath}' --pretty --disable=convertShapeToPath --enable=removeTitle --enable=removeDesc --enable=removeDoctype --enable=removeEmptyAttrs --enable=removeUnknownsAndDefaults --enable=removeUnusedNS --enable=removeEditorsNSData`,
-  ])
+function optimizeFilesWithSVGO(svgoPath, filePaths) {
+  const args = [
+    '--disable=convertShapeToPath',
+    '--enable=removeTitle',
+    '--enable=removeDesc',
+    '--enable=removeDoctype',
+    '--enable=removeEmptyAttrs',
+    '--enable=removeUnknownsAndDefaults',
+    '--enable=removeUnusedNS',
+    '--enable=removeEditorsNSData'
+  ]
+  filePaths.forEach(function(path){
+    args.push('"' + path + '"')
+  })
+  var fullCommand = svgoPath + ' ' + args.join(' ')
+  return runCommand('/bin/bash', ['-l', '-c', fullCommand])
 }
 
 // Utility function to play a given system sound.

--- a/examples/svgo-export/src/svgo-export.js
+++ b/examples/svgo-export/src/svgo-export.js
@@ -7,9 +7,61 @@
 // it was installed using `npm install --save sketch-utils`
 const toArray = require('sketch-utils/to-array')
 
+function getSVGOPath(context) {
+  return context.plugin.urlForResourceNamed('node_modules/svgo/bin/svgo').path()
+}
+
+// ### Helper Functions
+
+// Utility function to run a command line command with a set of arguments.
+function runCommand(command, args) {
+  const task = NSTask.alloc().init()
+  task.setLaunchPath_(command)
+  task.arguments = args
+  task.launch()
+  task.waitUntilExit()
+  return task.terminationStatus() == 0
+}
+
+function ensureSVGOExecutable(svgoPath) {
+  return runCommand('/bin/chmod', ['+x', svgoPath])
+}
+
+// This is the function where we call out to svgo to do the heavy lifting (i.e: compress all SVG files).
+//
+// The SVGO options are based on our experience working with Sketch's exported SVGs, and to the best of our knowledge
+// they shouldn't effect the rendering of your assets, just reduce their size.
+function optimizeFilesWithSVGO(svgoPath, filePaths) {
+  const args = [
+    '--disable=convertShapeToPath',
+    '--enable=removeTitle',
+    '--enable=removeDesc',
+    '--enable=removeDoctype',
+    '--enable=removeEmptyAttrs',
+    '--enable=removeUnknownsAndDefaults',
+    '--enable=removeUnusedNS',
+    '--enable=removeEditorsNSData',
+  ]
+  filePaths.forEach(path => args.push(`"${path}"`))
+  const fullCommand = `${svgoPath} ${args.join(' ')}`
+  return runCommand('/bin/bash', ['-l', '-c', fullCommand])
+}
+
+// Utility function to play a given system sound.
+function playSystemSound(sound) {
+  // The command line tool `afplay` does what we need - we just have to call it with the full path
+  // of a system sound.
+  return runCommand('/usr/bin/afplay', [`/System/Library/Sounds/${sound}.aiff`])
+}
+
+// Utility function to remove duplicates on an Array.
+function uniqueArray(arrArg) {
+  return arrArg.filter((elem, pos, arr) => arr.indexOf(elem) == pos)
+}
+
 // when the plugin starts, ensure we can run the svgo binary
-export function onStartup(context){
-  var svgoPath = getSVGOPath(context)
+export function onStartup(context) {
+  const svgoPath = getSVGOPath(context)
   ensureSVGOExecutable(svgoPath)
 }
 
@@ -34,8 +86,7 @@ export function onExportSlices(context) {
   const pathsToCompress = exportRequests
     .filter(currentExport => currentExport.request.format() == 'svg')
     .map(
-      currentExport =>
-        String(currentExport.path) // When we find an asset in SVG format, then we'll want to compress it
+      currentExport => String(currentExport.path) // When we find an asset in SVG format, then we'll want to compress it
     )
 
   if (pathsToCompress.length > 0) {
@@ -43,7 +94,7 @@ export function onExportSlices(context) {
     const paths = uniqueArray(pathsToCompress)
     let success = true
 
-    var svgoPath = getSVGOPath(context)
+    const svgoPath = getSVGOPath(context)
     success = optimizeFilesWithSVGO(svgoPath, paths)
 
     // Finally, make some noise to let the user know that we're done, and if everything went according to plan.
@@ -51,60 +102,6 @@ export function onExportSlices(context) {
     // The compression can take a while if you're exporting many assets, so it's a nice touch :-)
     playSystemSound(success ? 'Glass' : 'Basso')
   }
-}
-
-// ### Helper Functions
-
-// Utility function to run a command line command with a set of arguments.
-function runCommand(command, args) {
-  const task = NSTask.alloc().init()
-  task.setLaunchPath_(command)
-  task.arguments = args
-  task.launch()
-  task.waitUntilExit()
-  return task.terminationStatus() == 0
-}
-
-function getSVGOPath(context){
-  return context.plugin.urlForResourceNamed('node_modules/svgo/bin/svgo').path()
-}
-
-function ensureSVGOExecutable(svgoPath){
-  return runCommand('/bin/chmod', ['+x', svgoPath])
-}
-
-// This is the function where we call out to svgo to do the heavy lifting (i.e: compress all SVG files).
-//
-// The SVGO options are based on our experience working with Sketch's exported SVGs, and to the best of our knowledge
-// they shouldn't effect the rendering of your assets, just reduce their size.
-function optimizeFilesWithSVGO(svgoPath, filePaths) {
-  const args = [
-    '--disable=convertShapeToPath',
-    '--enable=removeTitle',
-    '--enable=removeDesc',
-    '--enable=removeDoctype',
-    '--enable=removeEmptyAttrs',
-    '--enable=removeUnknownsAndDefaults',
-    '--enable=removeUnusedNS',
-    '--enable=removeEditorsNSData'
-  ]
-  filePaths.forEach(function(path){
-    args.push('"' + path + '"')
-  })
-  var fullCommand = svgoPath + ' ' + args.join(' ')
-  return runCommand('/bin/bash', ['-l', '-c', fullCommand])
-}
-
-// Utility function to play a given system sound.
-function playSystemSound(sound) {
-  // The command line tool `afplay` does what we need - we just have to call it with the full path
-  // of a system sound.
-  return runCommand('/usr/bin/afplay', [`/System/Library/Sounds/${sound}.aiff`])
-}
-
-// Utility function to remove duplicates on an Array.
-function uniqueArray(arrArg) {
-  return arrArg.filter((elem, pos, arr) => arr.indexOf(elem) == pos)
 }
 
 // If you have questions, comments or any feedback, ping us at <developer@sketchapp.com>!

--- a/examples/svgo-export/webpack.skpm.config.js
+++ b/examples/svgo-export/webpack.skpm.config.js
@@ -1,0 +1,7 @@
+const CopyWebpackPlugin = require('copy-webpack-plugin')
+
+module.exports = function (config) {
+  config.plugins.push(
+    new CopyWebpackPlugin([ {from:'assets/node_modules', to:'../Resources/node_modules'} ], {})
+  );
+}

--- a/examples/svgo-export/webpack.skpm.config.js
+++ b/examples/svgo-export/webpack.skpm.config.js
@@ -1,7 +1,10 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 
-module.exports = function (config) {
+module.exports = function(config) {
   config.plugins.push(
-    new CopyWebpackPlugin([ {from:'assets/node_modules', to:'../Resources/node_modules'} ], {})
-  );
+    new CopyWebpackPlugin(
+      [{ from: 'assets/node_modules', to: '../Resources/node_modules' }],
+      {}
+    )
+  )
 }


### PR DESCRIPTION
fix #169 

* changed `assets` copying to `CopyWebpackPlugin` - the `assets` copying was really slow at build time, and was also completely flattening the directory structure - really fast now :)
* fixed `setLaunchPath_`
* fixed accessing the `svgo` binary resource
* fixed ensuring the `svgo` is executable