### PR TITLE
tidy svgo-export example

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -67,6 +67,12 @@ rules:
   # IMPORT
   import/prefer-default-export: off
   import/no-extraneous-dependencies: off
+  import/no-unresolved:
+    - error
+    - commonjs: true
+      caseSensitive: true
+      ignore:
+        - '^sketch(\/|$)'
   # TYPESCRIPT
   typescript/interface-name-prefix:
     - error

--- a/examples/svgo-export/package.json
+++ b/examples/svgo-export/package.json
@@ -1,6 +1,7 @@
 {
   "name": "svgo_export",
   "description": "Uses SVGO to compress exported SVG assets",
+  "license": "MIT",
   "author": "Ale Muñoz <ale@sketchapp.com>",
   "version": "0.1.0",
   "engines": {

--- a/examples/svgo-export/src/svgo-export.js
+++ b/examples/svgo-export/src/svgo-export.js
@@ -1,6 +1,9 @@
-// SVGO Export, by Ale Muñoz — Source code available at [GitHub](https://github.com/BohemianCoding/SketchAPI/tree/develop/examples/svgo-export)
-//
-// This Plugin compresses SVG assets using SVGO right after they're exported from Sketch.
+// SVGO Export, by Ale Muñoz
+// This plugin compresses SVG assets using SVGO right after they're exported from Sketch.
+// Source code -
+// [GitHub](https://github.com/BohemianCoding/SketchAPI/tree/develop/examples/svgo-export)
+// If you have questions, comments or any feedback, file an issue on Github or
+// ping us at <developer@sketchapp.com>!
 
 // we will need to call an executable
 const { execSync } = require('@skpm/child_process')
@@ -10,8 +13,31 @@ const { execSync } = require('@skpm/child_process')
 // it was installed using `npm install --save sketch-utils`
 const toArray = require('sketch-utils/to-array')
 
+// allows us to access the Sketch UI to post messages
+const UI = require('sketch/ui')
+
+// The SVGO options are based on our experience working with Sketch's exported SVGs, and
+// to the best of our knowledge they shouldn't effect the rendering of your assets, just reduce
+// their size.
+function optimizeFilesWithSVGO(svgPaths, svgoPath) {
+  return execSync(
+    `${svgoPath} --pretty --disable=convertShapeToPath --enable=removeTitle ` +
+      '--enable=removeDesc --enable=removeDoctype --enable=removeEmptyAttrs ' +
+      '--enable=removeUnknownsAndDefaults --enable=removeUnusedNS --enable=removeEditorsNSData ' +
+      `"${svgPaths.join('" "')}"`
+  )
+}
+
+// Utility function to play a given system sound.
+function playSystemSound(sound) {
+  // The command line tool `afplay` does what we need - we just have to call it with the full path
+  // of a system sound.
+  return execSync(`/usr/bin/afplay /System/Library/Sounds/${sound}.aiff`)
+}
+
 // ### Main Handler
-// This is the handler we defined on `manifest.json` for the event (`ExportSlices.finish`). It will be passed a `context` object as a parameter.
+// This is the handler we defined on `manifest.json` for the event (`ExportSlices`).
+// It will be passed a `context` object as a parameter.
 // `context.actionContext` is the action that has been triggered, and it looks like this:
 // ```json
 // {
@@ -23,69 +49,36 @@ const toArray = require('sketch-utils/to-array')
 // }
 // ```
 //
-// In this particular example, there's only one item in the `exports` array, but if you've exported 10.000 assets it will be a bit more crowded. The `ExportSlices.finish` event is only called once for the whole export operation, rather than being triggered 10.000 times.
+// In this particular example, there's only one item in the `exports` array, but if you've
+// exported 100 assets it will be a bit more crowded. The `ExportSlices` event is
+// only called once for the whole export operation, rather than being triggered 100 times.
 export function onExportSlices(context) {
+  // find all exported SVGs
   const exportRequests = toArray(context.actionContext.exports)
-
-  // We'll take a look at the Array that contains all the exported assets…
-  const pathsToCompress = exportRequests
+  const svgPaths = exportRequests
     .filter(currentExport => currentExport.request.format() == 'svg')
-    .map(
-      currentExport =>
-        String(currentExport.path.stringByDeletingLastPathComponent()) // When we find an asset in SVG format, then we'll want to compress the folder it's been exported to.
-    )
+    .map(currentExport => String(currentExport.path))
 
-  if (pathsToCompress.length > 0) {
-    // Let's remove duplicates so that we only compress each one once.
-    const paths = uniqueArray(pathsToCompress)
-    let success = true
-
-    // Now we run through each one...
-    paths.forEach(path => {
-      console.log(`Compressing SVG files in ${path}`)
-      // ...doing the export, and log the result to the console
-      if (optimizeFolderWithSVGO(context, path)) {
-        console.log('✅ compression ok')
-      } else {
-        console.log('❌ compression error')
-        success = false
-      }
-    })
-
-    // Finally, make some noise to let the user know that we're done, and if everything went according to plan.
-    //
-    // The compression can take a while if you're exporting many assets, so it's a nice touch :-)
-    playSystemSound(success ? 'Glass' : 'Basso')
+  if (svgPaths.length === 0) {
+    return
   }
-}
 
-// ### Helper Functions
+  const targetDesc = `${svgPaths.length} SVG file${
+    svgPaths.length == 1 ? '' : 's'
+  }`
+  UI.message(`Compressing ${targetDesc}`)
 
-// This is the function where we call out to svgo to do the heavy lifting (i.e: compress all SVG files in a given folder).
-//
-// svgo is installed installed in the Resources folder of our plugin so we need to get it from there.
-//
-// The SVGO options are based on our experience working with Sketch's exported SVGs, and to the best of our knowledge
-// they shouldn't effect the rendering of your assets, just reduce their size.
-function optimizeFolderWithSVGO(context, folderPath) {
-  const pathToSVGO = context.plugin
+  // svgo is installed installed in the Resources folder of our plugin so we need to get it
+  // from there
+  const svgoPath = context.plugin
     .urlForResourceNamed('node_modules/svgo/bin/svgo')
     .path()
-  return execSync(
-    `${pathToSVGO} --folder='${folderPath}' --pretty --disable=convertShapeToPath --enable=removeTitle --enable=removeDesc --enable=removeDoctype --enable=removeEmptyAttrs --enable=removeUnknownsAndDefaults --enable=removeUnusedNS --enable=removeEditorsNSData`
-  )
-}
+  const success = optimizeFilesWithSVGO(svgPaths, svgoPath)
 
-// Utility function to play a given system sound.
-function playSystemSound(sound) {
-  // The command line tool `afplay` does what we need - we just have to call it with the full path
-  // of a system sound.
-  return execSync(`/usr/bin/afplay /System/Library/Sounds/${sound}.aiff`)
+  // Finally, make some noise to let the user know that we're done, and if everything went
+  // according to plan. The compression can take a while if you're exporting many assets,
+  // so it's a nice touch :-)
+  const resultDesc = success ? 'Compressed' : 'Something went wrong compressing'
+  UI.message(`${resultDesc} ${targetDesc}`)
+  playSystemSound(success ? 'Glass' : 'Basso')
 }
-
-// Utility function to remove duplicates on an Array.
-function uniqueArray(arrArg) {
-  return arrArg.filter((elem, pos, arr) => arr.indexOf(elem) == pos)
-}
-
-// If you have questions, comments or any feedback, ping us at <developer@sketchapp.com>!


### PR DESCRIPTION
* only compress paths, not whole folder
* tidy comments
* print messages to `UI.message`
* make file pass `lint-staged`

I wasn't sure what to do about getting `require('sketch/ui')` to pass `lint-staged`, so let me know if ignoring it is right.