### PR TITLE
tests: use npm ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,8 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: npm install
+      - run: npm i -g npm@latest
+      - run: npm ci
 
       - save_cache:
           paths:

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: npm i -g npm@latest
+      - run: sudo npm i -g npm@latest
       - run: npm ci
 
       - save_cache:


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of CircleCI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable