### PR TITLE
fix Document save method when no path is provided

### DIFF
--- a/Source/dom/components/Document.js
+++ b/Source/dom/components/Document.js
@@ -166,7 +166,7 @@ export class Document extends WrappedObject {
     const error = MOPointer.alloc().init()
 
     if (!path) {
-      msdocument.saveDocument()
+      msdocument.saveDocument(null)
     } else {
       const url = getURLFromPath(path)
       const oldUrl = NSURL.URLWithString('not used')


### PR DESCRIPTION
Before this change, calling `document.save()` without passing a path was throwing the following error:

    ObjC method saveDocument: requires 1 argument, but JavaScript passed 0 arguments