### PR TITLE
Code Review: Improve support for Libraries in SketchAPI (#17854)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -72,6 +72,8 @@ globals:
   MSSharedTextReference: false
   MSUserAssetLibrary: false
   MSRemoteAssetLibrary: false
+  NSSaveAsOperation: false
+  NSSaveOperation: false
 
 rules:
   ###########

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,8 @@
 {
   "unreleased": [
+    "[New] Add `path` property to Document",
+    "[New] Add `lastModifiedAt` property to Library",
+    "[New] Disable/Enable a Library by setting its `enabled` property",
     "[Fixed] Setting an image override on a symbol instance",
     "[Fixed] Saving a document without specifying a path would fail"
   ],

--- a/Source/dom/components/Library.js
+++ b/Source/dom/components/Library.js
@@ -1,10 +1,28 @@
-import { WrappedObject, DefinedPropertiesKey } from '../WrappedObject'
-import { Document } from './Document'
-import { toArray, getURLFromPath, getDocumentData } from '../utils'
-import { Types } from '../enums'
-import { Factory } from '../Factory'
-import { wrapObject } from '../wrapNativeObject'
-import { ImportableObject, ImportableObjectType } from './ImportableObject'
+import {
+  WrappedObject,
+  DefinedPropertiesKey
+} from '../WrappedObject'
+import {
+  Document
+} from './Document'
+import {
+  toArray,
+  getURLFromPath,
+  getDocumentData
+} from '../utils'
+import {
+  Types
+} from '../enums'
+import {
+  Factory
+} from '../Factory'
+import {
+  wrapObject
+} from '../wrapNativeObject'
+import {
+  ImportableObject,
+  ImportableObjectType
+} from './ImportableObject'
 
 const AddStatus = {
   0: 'ok',
@@ -157,10 +175,21 @@ Library.define('valid', {
 })
 
 Library.define('enabled', {
+  get() {
+    return !!this._object.enabled()
+  },
+
+  set(enabled) {
+    this._object.setEnabled(enabled)
+  },
+})
+
+Library.define('lastModifiedAt', {
   exportable: true,
   importable: false,
   get() {
-    return !!this._object.enabled()
+    const date = this._object.dateLastModified()
+    return new Date(date.timeIntervalSince1970() * 1000)
   },
 })
 

--- a/Source/dom/components/__tests__/Document.test.js
+++ b/Source/dom/components/__tests__/Document.test.js
@@ -1,7 +1,13 @@
 /* globals expect, test */
-import { isRunningOnJenkins } from '../../../test-utils'
-import { Document } from '../Document'
-import { Group } from '../Group'
+import {
+  isRunningOnJenkins
+} from '../../../test-utils'
+import {
+  Document
+} from '../Document'
+import {
+  Group
+} from '../Group'
 
 test('should be able to log a document', (context, document) => {
   log(document)
@@ -9,7 +15,9 @@ test('should be able to log a document', (context, document) => {
 })
 
 test('should return the pages', (context, document) => {
-  const { pages } = document
+  const {
+    pages
+  } = document
   expect(pages.length).toBe(1)
   expect(pages[0]).toEqual(document.selectedPage)
 })
@@ -19,7 +27,11 @@ test('should return the selected layers', (context, document) => {
   expect(selection.isEmpty).toBe(true)
 
   const page = document.selectedPage
-  const group = new Group({ name: 'Test', parent: page, selected: true })
+  const group = new Group({
+    name: 'Test',
+    parent: page,
+    selected: true,
+  })
 
   expect(group.selected).not.toBe(false)
   expect(selection.isEmpty).toBe(false)
@@ -27,15 +39,23 @@ test('should return the selected layers', (context, document) => {
 
 test('should look for a layer by its id', (context, document) => {
   const page = document.selectedPage
-  const group = new Group({ name: 'Test', parent: page })
-  const { id } = group
+  const group = new Group({
+    name: 'Test',
+    parent: page,
+  })
+  const {
+    id
+  } = group
   const found = document.getLayerWithID(id)
   expect(found).toEqual(group)
 })
 
 test('should look for a layer by its name', (context, document) => {
   const page = document.selectedPage
-  const group = new Group({ name: 'Test', parent: page })
+  const group = new Group({
+    name: 'Test',
+    parent: page,
+  })
   const found = document.getLayersNamed('Test')
   expect(found).toEqual([group])
 })
@@ -53,9 +73,25 @@ if (!isRunningOnJenkins()) {
     expect(documents.find(d => d.id === documentId)).toEqual(_document)
   })
 
+  test('path should be undefined before saving it', () => {
+    expect(_document.path).toBe(undefined)
+  })
+
   test('should save a file', () => {
     const result = _document.save('~/Desktop/sketch-api-unit-tests.sketch')
     expect(result).toBe(_document)
+    expect(_document.path).toBe(String(NSString.stringWithString('~/Desktop/sketch-api-unit-tests.sketch').stringByExpandingTildeInPath()))
+  })
+
+  test('should save a file without specifying the path', () => {
+    const result = _document.save()
+    expect(result).toBe(_document)
+  })
+
+  test('should save a file to a specific path when setting the path', () => {
+    _document.path = '~/Desktop/sketch-api-unit-tests-2.sketch'
+    _document.save()
+    expect(_document.path).toBe(String(NSString.stringWithString('~/Desktop/sketch-api-unit-tests-2.sketch').stringByExpandingTildeInPath()))
   })
 
   test('should close a file', () => {

--- a/Source/dom/components/__tests__/Library.test.js
+++ b/Source/dom/components/__tests__/Library.test.js
@@ -1,6 +1,14 @@
 /* globals expect, test */
-import { isRunningOnJenkins } from '../../../test-utils'
-import { Library, Document, Artboard, Text, SymbolMaster } from '../../'
+import {
+  isRunningOnJenkins
+} from '../../../test-utils'
+import {
+  Library,
+  Document,
+  Artboard,
+  Text,
+  SymbolMaster
+} from '../../'
 
 function findValidLib(libs) {
   return libs.find(l => l.valid)
@@ -58,6 +66,18 @@ if (!isRunningOnJenkins()) {
 
     const libraries = Library.getLibraries()
     expect(libraries.find(d => d.id === libId)).toEqual(lib)
+  })
+
+  test('should disabled a library', () => {
+    expect(lib.enabled).toBe(true)
+    lib.enabled = false
+    expect(lib.enabled).toBe(false)
+    lib.enabled = true
+    expect(lib.enabled).toBe(true)
+  })
+
+  test('should get the lastModifiedAt date', () => {
+    expect(lib.lastModifiedAt instanceof Date).toBe(true)
   })
 
   test('should remove a library', () => {

--- a/docs/api/Document.md
+++ b/docs/api/Document.md
@@ -177,9 +177,11 @@ document.save('path/to/the/document.sketch')
 
 A method to save a document to a specific path or ask the user to choose where to save it.
 
-| Parameters                               |                                                                                                  |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| path<span class="arg-type">string</span> | The path where the document will be saved. If `undefined`, the user will be asked to select one. |
+| Parameters                                                          |                                                                                                  |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| path<span class="arg-type">string</span>                            | The path where the document will be saved. If `undefined`, the user will be asked to select one. |
+| options<span class="arg-type">object</span>                         | The options for the save operation (only used when specifing a path).                            |
+| options.saveMode<span class="arg-type">[SaveMode](#savemode)</span> | The way to save the document.                                                                    |
 
 ### Returns
 
@@ -192,3 +194,17 @@ document.close()
 ```
 
 A method to close a document.
+
+## `Document.SaveMode`
+
+```javascript
+Document.SaveMode.SaveAs
+```
+
+Enumeration of the save mode.
+
+| Value    |                                                                                                                               |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `Save`   | Overwrites a document’s file with the document’s contents                                                                     |
+| `SaveAs` | Writes a document’s contents to a new file and then changes the document’s current location to point to the just-written file |
+| `SaveTo` | Writes a document’s contents to a new file without changing the document’s current location to point to the new file.         |

--- a/docs/api/Library.md
+++ b/docs/api/Library.md
@@ -8,15 +8,16 @@ section: components
 var Library = require('sketch/dom').Library
 ```
 
-A Sketch Library. All the properties are `read-only`.
+A Sketch Library.
 
-| Properties                                                                  |                                              |
-| --------------------------------------------------------------------------- | -------------------------------------------- |
-| id<span class="arg-type">string</span>                                      | The unique ID of the Library.                |
-| name<span class="arg-type">string</span>                                    | The name of the Library.                     |
-| valid<span class="arg-type">boolean</span>                                  | If Sketch has been able to load the Library. |
-| enabled<span class="arg-type">boolean</span>                                | If the user has enabled the Library.         |
-| libraryType<span class="arg-type">[LibraryType](#librarylibrarytype)</span> | The type of Library.                         |
+| Properties                                                                             |                                                |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| id<span class="arg-type">string - readonly</span>                                      | The unique ID of the Library.                  |
+| name<span class="arg-type">string - readonly</span>                                    | The name of the Library.                       |
+| valid<span class="arg-type">boolean - readonly</span>                                  | If Sketch has been able to load the Library.   |
+| enabled<span class="arg-type">boolean</span>                                           | If the user has enabled the Library.           |
+| libraryType<span class="arg-type">[LibraryType](#librarylibrarytype) - readonly</span> | The type of Library.                           |
+| lastModifiedAt<span class="arg-type">Date - readonly</span>                            | The date at which the library was last updated |
 
 ## Access all the Libraries
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "npm run build",
     "watch": "webpack --watch",
     "deploy:docs": "./scripts/deploy.sh",
-    "run-tests:no-variant": "skpm-test",
+    "run-tests:no-variant": "skpm-test --app=latest",
     "run-tests": "skpm-test --app=xcode",
     "test": "npm run lint -- --quiet && npm run run-tests",
     "test:watch": "npm run run-tests -- --watch",


### PR DESCRIPTION
Resolves BohemianCoding/Sketch#17854

- [x] get details when a library was last updated (as shown in preferences)
- [x] enable/disable a library
- [x] get path of document if any

The following needs a block which is not possible in CocoaScript yet. So I'll revisit this when I've added it to CocoaScript (which we need anyway, more and more APIs use blocks)
- [ ] add a library from a URL