### PR TITLE
update "Running your plugin"

### DIFF
--- a/_guides/first-plugin.md
+++ b/_guides/first-plugin.md
@@ -29,6 +29,7 @@ cd my-plugin
 
 ## Running your plugin
 
+* Install npm modules: `npm install`
 * Build the plugin: `npm run build`
 * Launch Sketch, open a document
 * Choose `Plugins` > `my-plugin` > `My Command`


### PR DESCRIPTION
add `npm install` step before building the plugin with `npm run build`.