### PR TITLE
Library.getRemoteLibraryWithRSS: check for NSNull errors

### DIFF
--- a/Source/dom/components/Library.js
+++ b/Source/dom/components/Library.js
@@ -98,7 +98,7 @@ export class Library extends WrappedObject {
       coscript,
       (lib, err) => {
         try {
-          if (err) {
+          if (err && !(err instanceof NSNull)) {
             callback(new Error(err.description()))
           } else {
             callback(null, Library.fromNative(lib))


### PR DESCRIPTION
The "if (err)" check was returning true even when err is an NSNull