### PR TITLE
Fixed typo

### DIFF
--- a/docs/api/Page.md
+++ b/docs/api/Page.md
@@ -25,7 +25,7 @@ new Page()
 ```
 
 ```javascript
-new Artboard({
+new Page({
   name: 'my page',
 })
 ```


### PR DESCRIPTION
Should be "new Page" not "new Artboard" since providing instructions for creating a page.