### PR TITLE
fix a bunch of spellings

### DIFF
--- a/Source/dom/layers/Layer.js
+++ b/Source/dom/layers/Layer.js
@@ -210,7 +210,7 @@ Layer.define('name', {
 
 Layer.define('selected', {
   /**
-   * Wether the layer is selected or not.
+   * Whether the layer is selected or not.
    *
    * @return {Boolean} selected.
    */

--- a/Source/dom/layers/__tests__/Page.test.js
+++ b/Source/dom/layers/__tests__/Page.test.js
@@ -44,7 +44,7 @@ test('should remove a page', (context, document) => {
   expect(document.pages[0]).toEqual(page)
 })
 
-test('should return wether a page is selected or not', (context, document) => {
+test('should return whether a page is selected or not', (context, document) => {
   const page = document.selectedPage
   expect(page.selected).toBe(true)
 

--- a/docs/api/Flow.md
+++ b/docs/api/Flow.md
@@ -24,7 +24,7 @@ layer.flow = {
 }
 ```
 
-You can create a action without specifying an animation type, it will use the default one.
+You can create an action without specifying an animation type, it will use the default one.
 
 ```javascript
 layer.flow = {
@@ -32,7 +32,7 @@ layer.flow = {
 }
 ```
 
-You can create a action by using the ID of an Artboard instead of the artboard.
+You can create an action by using the ID of an Artboard instead of the artboard.
 
 ```javascript
 layer.flow = {

--- a/docs/api/Selection.md
+++ b/docs/api/Selection.md
@@ -29,7 +29,7 @@ selection.reduce((initial, layer) => {
 }, '')
 ```
 
-Even though a selection isn't an array, it defines `map`, `forEach` and `reduce` by just forwarding the arguments its layers. Those are just convenience methods to avoid getting the layers every time.
+Even though a selection isn't an array, it defines `map`, `forEach` and `reduce` by just forwarding the arguments to its layers. Those are just convenience methods to avoid getting the layers every time.
 
 ## Clear the Selection
 
@@ -37,7 +37,7 @@ Even though a selection isn't an array, it defines `map`, `forEach` and `reduce`
 selection.clear()
 ```
 
-Clear the selection.
+Clears the selection.
 
 ### Returns
 

--- a/docs/api/Style.md
+++ b/docs/api/Style.md
@@ -44,7 +44,7 @@ var isOutOfSync = style.isOutOfSyncWithSharedStyle(sharedStyle)
 
 ### Returns
 
-Wether the Style has some differences with a [Shared Style](#sharedstyle).
+Whether the Style has some differences with a [Shared Style](#sharedstyle).
 
 ## Sync the Style with a Shared Style
 
@@ -111,7 +111,7 @@ An object that represent the blur of the layer.
 | center<span class="arg-type">object</span>                       | The center of the blur (only used when the blur type is `Zoom`.   |
 | center.x<span class="arg-type">number</span>                     | The horizontal coordinate of the center of the blur.              |
 | center.y<span class="arg-type">number</span>                     | The vertical coordinate of the center of the blur.                |
-| enabled<span class="arg-type">boolean</span>                     | Wether the fill is active or not.                                 |
+| enabled<span class="arg-type">boolean</span>                     | Whether the fill is active or not.                                 |
 
 ## `Style.BlurType`
 
@@ -146,7 +146,7 @@ An object that represent a Fill.
 | fill<span class="arg-type">[FillType](#stylefilltype)</span> | The type of the fill.                            |
 | color<span class="arg-type">string</span>                    | A rgba hex-string (`#000000ff` is opaque black). |
 | gradient<span class="arg-type">[Gradient](#gradient)</span>  | The gradient of the fill.                        |
-| enabled<span class="arg-type">boolean</span>                 | Wether the fill is active or not.                |
+| enabled<span class="arg-type">boolean</span>                 | Whether the fill is active or not.                |
 
 ## `Style.FillType`
 
@@ -182,7 +182,7 @@ An object that represent a Border.
 | fillType<span class="arg-type">[FillType](#stylefilltype)</span>             | The type of the fill of the border.              |
 | color<span class="arg-type">string</span>                                    | A rgba hex-string (`#000000ff` is opaque black). |
 | gradient<span class="arg-type">[Gradient](#gradient)</span>                  | The gradient of the fill.                        |
-| enabled<span class="arg-type">boolean</span>                                 | Wether the border is active or not.              |
+| enabled<span class="arg-type">boolean</span>                                 | Whether the border is active or not.              |
 | position<span class="arg-type">[BorderPosition](#styleborderposition)</span> | The position of the border.                      |
 | thickness<span class="arg-type">number</span>                                | The thickness of the border.                     |
 
@@ -294,7 +294,7 @@ An object that represent a Shadow.
 | x<span class="arg-type">number</span>        | The horizontal offset of the shadow.             |
 | y<span class="arg-type">number</span>        | The vertical offset of the shadow.               |
 | spread<span class="arg-type">number</span>   | The spread of the shadow.                        |
-| enabled<span class="arg-type">boolean</span> | Wether the fill is active or not.                |
+| enabled<span class="arg-type">boolean</span> | Whether the fill is active or not.                |
 
 ## Gradient
 

--- a/docs/api/Text.md
+++ b/docs/api/Text.md
@@ -22,7 +22,7 @@ A text layer. It is an instance of [Layer](#layer) so all the methods defined th
 | text<span class="arg-type">string</span>                                 | The string value of the text layer.                                                            |
 | alignment<span class="arg-type">[Alignment](#textalignment)</span>       | The alignment of the layer.                                                                    |
 | lineSpacing<span class="arg-type">[LineSpacing](#textlinespacing)</span> | The line spacing of the layer.                                                                 |
-| fixedWidth<span class="arg-type">boolean</span>                          | Wether the layer should have a fixed width or a flexible width.                                |
+| fixedWidth<span class="arg-type">boolean</span>                          | Whether the layer should have a fixed width or a flexible width.                                |
 
 ## Create a new Text
 

--- a/docs/api/wrapped-object.md
+++ b/docs/api/wrapped-object.md
@@ -12,5 +12,5 @@ Each [Component](#document) follows the same API:
 - `Component.toJSON()` return a JSON object that represent the component
 - `new Component(properties)` creates a new native Sketch model object and returns a wrapped object
 - `componentInstance.sketchObject` returns the native Sketch model object.
-- `componentInstance.isImmutable()` returns if the component is wrapping an immutable version of a native Sketch model object. If that is the case, you won't be able to mutable the object (setting any property will be a no-op).
+- `componentInstance.isImmutable()` returns `true` if the component is wrapping an immutable version of a native Sketch model object. If that is the case, you won't be able to mutable the object (setting any property will be a no-op).
 - `componentInstance.type` returns a string that represent the type of the component. If it's `undefined`, it means that we couldn't match the native object and that we returned a really lightweight wrapper.

--- a/examples/svgo-export/README.md
+++ b/examples/svgo-export/README.md
@@ -57,7 +57,7 @@ To customize webpack create `webpack.skpm.config.js` file which exports function
  * Supports asynchronous changes when promise is returned.
  *
  * @param {object} config - original webpack config.
- * @param {boolean} isPluginCommand - wether the config is for a plugin command or a resource
+ * @param {boolean} isPluginCommand - whether the config is for a plugin command or a resource
  **/
 module.exports = function(config, isPluginCommand) {
   /** you can change config here **/


### PR DESCRIPTION
• Fixed spelling of `whether`. At a number of places whether was misspelled as `wether`
• Replaced `a` with `an` wherever required