### PR TITLE
Add verticalAlignment to Text

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": ["[New] Add verticalAlignment to Text"],
+  "unreleased": [
+      "[New] Add `verticalAlignment` property to Text"
+  ],
   "releases": {
     "52.1": ["[New] Add basic support for Shape path"],
     "52": [

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,5 @@
 {
-  "unreleased": [],
+  "unreleased": ["[New] Add verticalAlignment to Text"],
   "releases": {
     "52.1": ["[New] Add basic support for Shape path"],
     "52": [

--- a/Source/dom/layers/Text.js
+++ b/Source/dom/layers/Text.js
@@ -44,7 +44,7 @@ const VerticalTextAlignment = {
 }
 
 export const VerticalTextAlignmentMap = {
-  left: 0, // Visually left aligned
+  top: 0, // Visually left aligned
   center: 1, // Visually centered
   bottom: 2, // Visually bottom aligned
 }

--- a/Source/dom/layers/Text.js
+++ b/Source/dom/layers/Text.js
@@ -36,6 +36,19 @@ export const TextAlignmentMap = {
   natural: 4, // Indicates the default alignment for script
 }
 
+// Mapping between vertical text alignment names and values.
+const VerticalTextAlignment = {
+  top: 'top', // Visually top aligned
+  center: 'center', // Visually center aligned
+  bottom: 'bottom', // Visually bottom aligned
+}
+
+export const VerticalTextAlignmentMap = {
+  left: 0, // Visually left aligned
+  center: 1, // Visually centered
+  bottom: 2, // Visually bottom aligned
+}
+
 /**
  * Represents a text layer.
  */
@@ -208,6 +221,41 @@ Text.define('alignment', {
     }
     const translated = TextAlignmentMap[mode]
     this._object.textAlignment =
+      typeof translated !== 'undefined' ? translated : mode
+  },
+})
+
+Text.VerticalAlignment = VerticalTextAlignment
+Text.define('verticalAlignment', {
+  /**
+   * The vertical alignment of the layer.
+   * This will be one of the values: "top", "center", "bottom".
+   *
+   * @return {string} The vertical alignment mode.
+   */
+  get() {
+    const raw = this._object.verticalAlignment()
+    return (
+      Object.keys(VerticalTextAlignmentMap).find(
+        key => VerticalTextAlignmentMap[key] === raw
+      ) || raw
+    )
+  },
+
+  /**
+   * Set the vertical alignment of the layer.
+   *
+   * The mode supplied can be a string or a number.
+   * If it's a string, it should be one of the values: "top", "center", "bottom";
+   *
+   * @param {string} mode The vertical alignment mode to use.
+   */
+  set(mode) {
+    if (this.isImmutable()) {
+      return
+    }
+    const translated = VerticalTextAlignmentMap[mode]
+    this._object.verticalAlignment =
       typeof translated !== 'undefined' ? translated : mode
   },
 })

--- a/Source/dom/layers/Text.js
+++ b/Source/dom/layers/Text.js
@@ -44,7 +44,7 @@ const VerticalTextAlignment = {
 }
 
 export const VerticalTextAlignmentMap = {
-  top: 0, // Visually left aligned
+  top: 0, // Visually top aligned
   center: 1, // Visually centered
   bottom: 2, // Visually bottom aligned
 }

--- a/Source/dom/layers/__tests__/Text.test.js
+++ b/Source/dom/layers/__tests__/Text.test.js
@@ -49,14 +49,14 @@ test('should change the text alignment', () => {
   })
 })
 
-test('should change the text alignment', () => {
+test('should change the text vertical alignment', () => {
   const text = new Text({
     text: 'blah',
     frame: new Rectangle(10, 10, 1000, 1000),
   })
 
-  // default to left
-  expect(text.alignment).toBe(Text.Alignment.left)
+  // default to top
+  expect(text.verticalAlignment).toBe(Text.VerticalAlignment.top)
 
   Object.keys(Text.VerticalAlignment).forEach(key => {
     // test setting by name

--- a/Source/dom/layers/__tests__/Text.test.js
+++ b/Source/dom/layers/__tests__/Text.test.js
@@ -1,6 +1,10 @@
 /* globals expect, test */
 import { Text, Rectangle } from '../..'
-import { TextAlignmentMap, TextLineSpacingBehaviourMap } from '../Text'
+import {
+  TextAlignmentMap,
+  VerticalTextAlignmentMap,
+  TextLineSpacingBehaviourMap,
+} from '../Text'
 
 test('should create a Text layer', () => {
   const text = new Text()
@@ -42,6 +46,26 @@ test('should change the text alignment', () => {
     // test setting by value
     text.alignment = TextAlignmentMap[key]
     expect(text.alignment).toBe(Text.Alignment[key])
+  })
+})
+
+test('should change the text alignment', () => {
+  const text = new Text({
+    text: 'blah',
+    frame: new Rectangle(10, 10, 1000, 1000),
+  })
+
+  // default to left
+  expect(text.alignment).toBe(Text.Alignment.left)
+
+  Object.keys(Text.VerticalAlignment).forEach(key => {
+    // test setting by name
+    text.verticalAlignment = key
+    expect(text.verticalAlignment).toBe(Text.VerticalAlignment[key])
+
+    // test setting by value
+    text.verticalAlignment = VerticalTextAlignmentMap[key]
+    expect(text.verticalAlignment).toBe(Text.VerticalAlignment[key])
   })
 })
 

--- a/docs/api/Text.md
+++ b/docs/api/Text.md
@@ -10,19 +10,20 @@ var Text = require('sketch/dom').Text
 
 A text layer. It is an instance of [Layer](#layer) so all the methods defined there are available.
 
-| Properties                                                               |                                                                                                |
-| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| id<span class="arg-type">string</span>                                   | The unique ID of the Text.                                                                     |
-| name<span class="arg-type">string</span>                                 | The name of the Text                                                                           |
-| parent<span class="arg-type">[Group](#group)</span>                      | The group the Text is in.                                                                      |
-| frame<span class="arg-type">[Rectangle](#rectangle)</span>               | The frame of the Text. This is given in coordinates that are local to the parent of the layer. |
-| flow<span class="arg-type">[Flow](#flow)</span>                          | The prototyping action associated with the Text.                                               |
-| style<span class="arg-type">[Style](#style)</span>                       | The style of the Text.                                                                         |
-| sharedStyleId<span class="arg-type">string / null</span>                 | The ID of the [SharedStyle](#sharedstyle) this Text is linked to if any.                       |
-| text<span class="arg-type">string</span>                                 | The string value of the text layer.                                                            |
-| alignment<span class="arg-type">[Alignment](#textalignment)</span>       | The alignment of the layer.                                                                    |
-| lineSpacing<span class="arg-type">[LineSpacing](#textlinespacing)</span> | The line spacing of the layer.                                                                 |
-| fixedWidth<span class="arg-type">boolean</span>                          | Whether the layer should have a fixed width or a flexible width.                                |
+| Properties                                                                             |                                                                                                |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| id<span class="arg-type">string</span>                                                 | The unique ID of the Text.                                                                     |
+| name<span class="arg-type">string</span>                                               | The name of the Text                                                                           |
+| parent<span class="arg-type">[Group](#group)</span>                                    | The group the Text is in.                                                                      |
+| frame<span class="arg-type">[Rectangle](#rectangle)</span>                             | The frame of the Text. This is given in coordinates that are local to the parent of the layer. |
+| flow<span class="arg-type">[Flow](#flow)</span>                                        | The prototyping action associated with the Text.                                               |
+| style<span class="arg-type">[Style](#style)</span>                                     | The style of the Text.                                                                         |
+| sharedStyleId<span class="arg-type">string / null</span>                               | The ID of the [SharedStyle](#sharedstyle) this Text is linked to if any.                       |
+| text<span class="arg-type">string</span>                                               | The string value of the text layer.                                                            |
+| alignment<span class="arg-type">[Alignment](#textalignment)</span>                     | The alignment of the layer.                                                                    |
+| verticalAlignment<span class="arg-type">[VerticalAlignment](#verticalalignment)</span> | The vertical alignment of the layer.                                                           |
+| lineSpacing<span class="arg-type">[LineSpacing](#textlinespacing)</span>               | The line spacing of the layer.                                                                 |
+| fixedWidth<span class="arg-type">boolean</span>                                        | Whether the layer should have a fixed width or a flexible width.                               |
 
 ## Create a new Text
 
@@ -92,6 +93,20 @@ Enumeration of the alignments of the text.
 | `center`  | Visually centered                                                 |
 | `justify` | Fully-justified. The last line in a paragraph is natural-aligned. |
 | `natural` | Indicates the default alignment for script                        |
+
+## `Text.VerticalAlignment`
+
+```javascript
+Text.VerticalAlignment.center
+```
+
+Enumeration of the vertical alignments of the text.
+
+| Value    |                              |
+| -------- | ---------------------------- |
+| `top`    | Visually top aligned         |
+| `center` | Visually vertically centered |
+| `bottom` | Visually bottom aligned      |
 
 ## `Text.LineSpacing`
 


### PR DESCRIPTION
Adds `verticalAlignment` and `VerticalAlignment` to `Text`.

I am reading the vertical alignment of text fields in a plugin, and figured that I would make this as it is a small feature that was missing.
Note: As of Sketch 52.3, `MSImmutableTextLayer` appears to not implement a getter for `verticalAlignment`, so as currently written this feature isn't safe. I could add a check to make sure that the property exists, or the PR can wait for an implementation to be added to Sketch.