### PR TITLE
Allow duplicating a layer without a parent

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -7,12 +7,11 @@
     "[Improved] Be more aggressive in finding the selected document",
     "[New] Add `noise` and `pattern` properties on Fill",
     "[Fixed] Setting `flow` as `undefined` on a Layer",
-    "[Improved] `selectedPage` and `selectedLayers` can now be set on the Document"
+    "[Improved] `selectedPage` and `selectedLayers` can now be set on the Document",
+    "[Improved] `layer.duplicate` now works on a layer with no parent"
   ],
   "releases": {
-    "53.1": [
-      "[Fixed] Setting mutable colors where it should"
-    ],
+    "53.1": ["[Fixed] Setting mutable colors where it should"],
     "53": [
       "[Improved] Obj-C exceptions will be thrown as JS Errors which will reference the exception in their `nativeException` property",
       "[Improved] `setTimeout` and all the other timeout, interval, immediate methods are now available directly, no need to polyfill them",

--- a/Source/dom/layers/Layer.js
+++ b/Source/dom/layers/Layer.js
@@ -20,7 +20,9 @@ export class Layer extends WrappedObject {
   duplicate() {
     const object = this._object
     const duplicate = object.copy()
-    object.parentGroup().insertLayers_afterLayer([duplicate], object)
+    if (object.parentGroup()) {
+      object.parentGroup().insertLayers_afterLayer([duplicate], object)
+    }
     return wrapNativeObject(duplicate)
   }
 

--- a/Source/dom/layers/__tests__/Layer.test.js
+++ b/Source/dom/layers/__tests__/Layer.test.js
@@ -41,6 +41,12 @@ test('should duplicate the layer and add it as a sibling', (context, document) =
   expect(result.type).toBe('Group')
 })
 
+test('should duplicate the layer with no parent', () => {
+  const group = new Group()
+  const result = group.duplicate()
+  expect(result.type).toBe('Group')
+})
+
 test('should remove the layer from its parent', (context, document) => {
   const page = document.selectedPage
   const group = new Group({


### PR DESCRIPTION
Address #376 and allow `layer.duplicate()` to complete even when the initial layer doesn't have a parent.