### PR TITLE
Updating when overrides are populated

### DIFF
--- a/docs/api/Override.md
+++ b/docs/api/Override.md
@@ -8,7 +8,7 @@ section: models
 var overrides = symbolInstance.overrides
 ```
 
-A [Symbol](https://www.sketchapp.com/docs/symbols/) override. This component is not exposed, it is only returned when accessing the `overrides` of a [Symbol Instance](#symbol-instance).
+A [Symbol](https://www.sketchapp.com/docs/symbols/) override. This component is not exposed, it is only returned when accessing the `overrides` of a [Symbol Instance](#symbol-instance). The overrides are not available until after the instance is injected into the document.
 
 | Properties                                                                                                      |                                                                                                                                                                                                                                                                                                                    |
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
Overrides are null when an instance is created. Once an instance is pushed into the document, the overrides become available. This is ambiguous in the current documentation and might cost a lot of developer hours.