### PR TITLE
Code Review: Sketch Dev Tools can't be opened (#23921)

### DIFF
--- a/Source/async/index.ts
+++ b/Source/async/index.ts
@@ -1,4 +1,7 @@
-module.exports = require('./async')
+const Async = require('./async')
+
+module.exports = Async
+module.exports.default = Async
 
 module.exports.version = {
   sketch: MSApplicationMetadata.metadata().appVersion,

--- a/Source/data-supplier/index.ts
+++ b/Source/data-supplier/index.ts
@@ -1,4 +1,7 @@
-module.exports = require('./DataSupplier')
+const DataSupplier = require('./DataSupplier')
+
+module.exports = DataSupplier
+module.exports.default = DataSupplier
 
 module.exports.version = {
   sketch: MSApplicationMetadata.metadata().appVersion,

--- a/Source/dom/index.js
+++ b/Source/dom/index.js
@@ -75,6 +75,7 @@ const DOM = {
 }
 
 module.exports = DOM
+module.exports.default = DOM
 
 module.exports.version = {
   sketch: MSApplicationMetadata.metadata().appVersion,

--- a/Source/index.ts
+++ b/Source/index.ts
@@ -1,4 +1,7 @@
-module.exports = require('./dom')
+const DOM = require('./dom')
+
+module.exports = DOM
+module.exports.default = DOM
 
 module.exports.Async = require('./async')
 module.exports.DataSupplier = require('./data-supplier')

--- a/Source/index.ts
+++ b/Source/index.ts
@@ -1,9 +1,8 @@
-const DOM = require('./dom')
+const completeExport = require('./dom')
+completeExport.Async = require('./async')
+completeExport.DataSupplier = require('./data-supplier')
+completeExport.Settings = require('./settings')
+completeExport.UI = require('./ui')
 
-module.exports = DOM
-module.exports.default = DOM
-
-module.exports.Async = require('./async')
-module.exports.DataSupplier = require('./data-supplier')
-module.exports.Settings = require('./settings')
-module.exports.UI = require('./ui')
+module.exports = completeExport
+module.exports.default = completeExport

--- a/Source/settings/index.ts
+++ b/Source/settings/index.ts
@@ -1,4 +1,7 @@
-module.exports = require('./Settings')
+const Settings = require('./Settings')
+
+module.exports = Settings
+module.exports.default = Settings
 
 module.exports.version = {
   sketch: MSApplicationMetadata.metadata().appVersion,

--- a/Source/ui/index.ts
+++ b/Source/ui/index.ts
@@ -1,4 +1,7 @@
-module.exports = require('./UI')
+const UI = require('./UI')
+
+module.exports = UI
+module.exports.default = UI
 
 module.exports.version = {
   sketch: MSApplicationMetadata.metadata().appVersion,


### PR DESCRIPTION
fix BohemianCoding/Sketch#23921

Now I'm manually exporting both `module.exports` and `module.exports.default` (which is what `import sketch from 'sketch'` is looking for)