### PR TITLE
fix inserting shared styles

### DIFF
--- a/Source/dom/models/Document.js
+++ b/Source/dom/models/Document.js
@@ -622,162 +622,133 @@ Document.define('gradients', {
   },
 })
 
-Document.define('sharedLayerStyles', {
-  array: true,
-  get() {
-    if (!this._object) {
-      return []
-    }
-    const documentData = this._getMSDocumentData()
-    return toArray(documentData.allLayerStyles()).map(wrapObject)
-  },
-  set(sharedLayerStyles) {
-    if (this.isImmutable()) {
-      return
-    }
-    const documentData = this._getMSDocumentData()
-    const container = documentData.sharedObjectContainerOfType(1)
-
-    // remove the existing shared styles
-    container.removeAllSharedObjects()
-
-    container.addSharedObjects(
-      toArray(sharedLayerStyles).map(item => {
-        let sharedStyle
-
-        if (isWrappedObject(item)) {
-          sharedStyle = item.sketchObject
-        } else if (isNativeObject(item)) {
-          sharedStyle = item
-        } else {
-          const wrappedStyle = wrapObject(item.style, Types.Style)
-
-          sharedStyle = MSSharedStyle.alloc().initWithName_style(
-            item.name,
-            wrappedStyle.sketchObject
-          )
-        }
-        return sharedStyle
-      })
-    )
-  },
-  insertItem(item, index) {
-    if (this.isImmutable()) {
-      return undefined
-    }
-
-    const documentData = this._getMSDocumentData()
-
-    let sharedStyle
-
+function isLocalSharedStyle(libraryController) {
+  return item => {
     if (isWrappedObject(item)) {
-      sharedStyle = item.sketchObject
-    } else if (isNativeObject(item)) {
-      sharedStyle = item
-    } else {
-      const wrappedStyle = wrapObject(item.style, Types.Style)
-
-      sharedStyle = MSSharedStyle.alloc().initWithName_style(
-        item.name,
-        wrappedStyle.sketchObject
+      return (
+        !libraryController.libraryForShareableObject(item.sketchObject) &&
+        !item.sketchObject.foreignObject()
       )
     }
-
-    const container = documentData.sharedObjectContainerOfType(1)
-
-    container.insertSharedObject_atIndex(sharedStyle, index)
-
-    return new SharedStyle({ sketchObject: sharedStyle })
-  },
-  removeItem(index) {
-    if (this.isImmutable()) {
-      return undefined
-    }
-    const documentData = this._getMSDocumentData()
-    const container = documentData.sharedObjectContainerOfType(1)
-
-    const removed = documentData.allLayerStyles()[index]
-    container.removeSharedObjectAtIndex(index)
-    return wrapObject(removed, Types.SharedStyle)
-  },
-})
-
-Document.define('sharedTextStyles', {
-  array: true,
-  get() {
-    if (!this._object) {
-      return []
-    }
-    const documentData = this._getMSDocumentData()
-    return toArray(documentData.allTextStyles()).map(wrapObject)
-  },
-  set(sharedLayerStyles) {
-    if (this.isImmutable()) {
-      return
-    }
-    const documentData = this._getMSDocumentData()
-    const container = documentData.sharedObjectContainerOfType(2)
-
-    // remove the existing shared styles
-    container.removeAllSharedObjects()
-
-    container.addSharedObjects(
-      toArray(sharedLayerStyles).map(item => {
-        let sharedStyle
-
-        if (isWrappedObject(item)) {
-          sharedStyle = item.sketchObject
-        } else if (isNativeObject(item)) {
-          sharedStyle = item
-        } else {
-          const wrappedStyle = wrapObject(item.style, Types.Style)
-
-          sharedStyle = MSSharedStyle.alloc().initWithName_style(
-            item.name,
-            wrappedStyle.sketchObject
-          )
-        }
-        return sharedStyle
-      })
-    )
-  },
-  insertItem(item, index) {
-    if (this.isImmutable()) {
-      return undefined
-    }
-
-    const documentData = this._getMSDocumentData()
-
-    let sharedStyle
-
-    if (isWrappedObject(item)) {
-      sharedStyle = item.sketchObject
-    } else if (isNativeObject(item)) {
-      sharedStyle = item
-    } else {
-      const wrappedStyle = wrapObject(item.style, Types.Style)
-
-      sharedStyle = MSSharedStyle.alloc().initWithName_style(
-        item.name,
-        wrappedStyle.sketchObject
+    if (isNativeObject(item)) {
+      return (
+        !!libraryController.libraryForShareableObject(item) &&
+        !!item.foreignObject()
       )
     }
+    return true
+  }
+}
 
-    const container = documentData.sharedObjectContainerOfType(2)
+function sharedStyleDescriptor(type) {
+  const config = {
+    localStyles: type === 'layer' ? 'layerStyles' : 'layerTextStyles',
+    foreignStyles:
+      type === 'layer' ? 'foreignLayerStyles' : 'foreignTextStyles',
+    type: type === 'layer' ? 1 : 2,
+  }
 
-    container.insertSharedObject_atIndex(sharedStyle, index)
+  return {
+    array: true,
+    get() {
+      if (!this._object) {
+        return []
+      }
+      const documentData = this._getMSDocumentData()
+      const localStyles = toArray(documentData[config.localStyles]().objects())
+      const foreignStyles = toArray(documentData[config.foreignStyles]()).map(
+        foreign => foreign.localSharedStyle()
+      )
+      return foreignStyles.concat(localStyles).map(wrapObject)
+    },
+    set(sharedLayerStyles) {
+      if (this.isImmutable()) {
+        return
+      }
+      const documentData = this._getMSDocumentData()
+      const container = documentData.sharedObjectContainerOfType(config.type)
 
-    return new SharedStyle({ sketchObject: sharedStyle })
-  },
-  removeItem(index) {
-    if (this.isImmutable()) {
-      return undefined
-    }
-    const documentData = this._getMSDocumentData()
-    const container = documentData.sharedObjectContainerOfType(2)
+      // remove the existing shared styles
+      container.removeAllSharedObjects()
 
-    const removed = documentData.allTextStyles()[index]
-    container.removeSharedObjectAtIndex(index)
-    return wrapObject(removed, Types.SharedStyle)
-  },
-})
+      const libraryController = AppController.sharedInstance().librariesController()
+
+      container.addSharedObjects(
+        toArray(sharedLayerStyles)
+          .filter(isLocalSharedStyle(libraryController))
+          .map(item => {
+            let sharedStyle
+
+            if (isWrappedObject(item)) {
+              sharedStyle = item.sketchObject
+            } else if (isNativeObject(item)) {
+              sharedStyle = item
+            } else {
+              const wrappedStyle = wrapObject(item.style, Types.Style)
+
+              sharedStyle = MSSharedStyle.alloc().initWithName_style(
+                item.name,
+                wrappedStyle.sketchObject
+              )
+            }
+            return sharedStyle
+          })
+      )
+    },
+    insertItem(item, index) {
+      if (this.isImmutable()) {
+        return undefined
+      }
+
+      const documentData = this._getMSDocumentData()
+
+      const realIndex = Math.max(
+        index - documentData[config.foreignStyles]().length,
+        0
+      )
+
+      let sharedStyle
+
+      if (isWrappedObject(item)) {
+        sharedStyle = item.sketchObject
+      } else if (isNativeObject(item)) {
+        sharedStyle = item
+      } else {
+        const wrappedStyle = wrapObject(item.style, Types.Style)
+
+        sharedStyle = MSSharedStyle.alloc().initWithName_style(
+          item.name,
+          wrappedStyle.sketchObject
+        )
+      }
+
+      const container = documentData.sharedObjectContainerOfType(config.type)
+
+      container.insertSharedObject_atIndex(sharedStyle, realIndex)
+
+      return new SharedStyle({ sketchObject: sharedStyle })
+    },
+    removeItem(index) {
+      if (this.isImmutable()) {
+        return undefined
+      }
+      const documentData = this._getMSDocumentData()
+
+      const realIndex = index - documentData[config.foreignStyles]().length
+
+      if (realIndex < 0) {
+        console.log('Cannot remove a foreign shared style')
+        return undefined
+      }
+
+      const container = documentData.sharedObjectContainerOfType(config.type)
+
+      const removed = container.objects()[realIndex]
+      container.removeSharedObjectAtIndex(realIndex)
+      return wrapObject(removed, Types.SharedStyle)
+    },
+  }
+}
+
+Document.define('sharedLayerStyles', sharedStyleDescriptor('layer'))
+Document.define('sharedTextStyles', sharedStyleDescriptor('text'))

--- a/Source/dom/models/SharedStyle.js
+++ b/Source/dom/models/SharedStyle.js
@@ -22,9 +22,6 @@ export class SharedStyle extends WrappedObject {
   }
 
   static fromStyle({ name, style, document } = {}) {
-    console.warn(
-      `\`SharedStyle.fromStyle({ name, style, document })\` is deprecated. Use \`document.sharedLayerStyles.push({ name, style })\` (or \`document.sharedTextStyles\`) instead.`
-    )
     const documentData = wrapObject(document)._getMSDocumentData()
     const wrappedStyle = wrapObject(style, Types.Style)
 

--- a/docs/api/SharedStyle.md
+++ b/docs/api/SharedStyle.md
@@ -27,17 +27,17 @@ A shared style (either a layer style or a text style).
 ## Create a new Shared Style from a Style
 
 ```javascript
+const newSharedStyle = SharedStyle.fromStyle({
+  name: 'Header 1',
+  style: layer.style,
+  document: document,
+})
+
+// you can also push to the shared styles arrays directly
 document.sharedTextStyles.push({
   name: 'Header 1',
   style: text.style,
 })
-
-const newSharedStylesNumber = document.sharedLayerStyles.push({
-  name: 'Red Background',
-  style: shape.style,
-})
-
-const newSharedStyle = document.sharedLayerStyles[newSharedStylesNumber]
 ```
 
 Create a new Shared Style with a specific name in a specific Document.

--- a/docs/api/SharedStyle.md
+++ b/docs/api/SharedStyle.md
@@ -32,13 +32,17 @@ document.sharedTextStyles.push({
   style: text.style,
 })
 
-document.sharedLayerStyles.push({
+const newSharedStylesNumber = document.sharedLayerStyles.push({
   name: 'Red Background',
   style: shape.style,
 })
+
+const newSharedStyle = document.sharedLayerStyles[newSharedStylesNumber]
 ```
 
 Create a new Shared Style with a specific name in a specific Document.
+
+> ⚠️You can only insert local shared styles (eg. not linked to a Library). `document.sharedLayerStyles` returns the foreign shared styles (eg. linked to a Library) concatenated with the local shared styles. So if you try to insert a new Shared Style at the beginning (using `unshift` for example), it will end up at the beginning of the local Shared Styles but that might not be the beginning of all the shared styles if there are some foreign.
 
 ## Get all the Instances
 


### PR DESCRIPTION
You can only insert local shared styles (eg. not linked to a Library). `document.sharedLayerStyles` returns the foreign shared styles (eg. linked to a Library) concatenated with the local shared styles.

So if you tried to insert a shared style (using `sharedStyles.push`), it would throw an index out of bounds error if there were some foreign shared styles.

Now it won't but if you try to insert a new Shared Style at the beginning (using `unshift` for example), it will end up at the beginning of the local Shared Styles but that might not be the beginning of all the shared styles if there are some foreign.

I don't think there is a perfect solution :(

For that reason, I decided, to de-deprecate `SharedStyle.fromStyle` which is just cleaner when you want to create a shared style and get a reference to it.