### PR TITLE
Fix error in Shapepath documentation

### DIFF
--- a/docs/api/ShapePath.md
+++ b/docs/api/ShapePath.md
@@ -5,7 +5,7 @@ section: layers
 ---
 
 ```javascript
-var Shape = require('sketch/dom').Shape
+var ShapePath = require('sketch/dom').ShapePath
 ```
 
 A shape path layer. It is an instance of [Layer](#layer) so all the methods defined there are available.


### PR DESCRIPTION
It’s super confusing to conflate creating `Shape` objects with `ShapePath`. Hopefully this fix will help people be less confused.