### PR TITLE
getSymbolsPage returns `undefined` not `null`

### DIFF
--- a/docs/api/Page.md
+++ b/docs/api/Page.md
@@ -63,7 +63,7 @@ A method to get the Symbols Page of a Document.
 
 #### Returns
 
-Return a [Page](#page) or `null` if there is no Symbols Page yet.
+Return a [Page](#page) or `undefined` if there is no Symbols Page yet.
 
 ### Create the Symbols Page
 


### PR DESCRIPTION
Thought it would be better to make a PR rather than an issue for this. When I log `.getSymbolsPage(document)` and there is no Page titled “Symbols”, the method returns `undefined` and not `null`