### PR TITLE
fix lint in examples

### DIFF
--- a/examples/hello-world/src/hello-world.js
+++ b/examples/hello-world/src/hello-world.js
@@ -6,12 +6,12 @@
 // let's get a hold on the Sketch API
 const sketch = require('sketch')
 
-export default function(context) {
-  // We are passed a context variable when we're run.
-  // We use this to get hold of the native Sketch document and wrap it.
-  const document = sketch.fromNative(context.document)
+// eslint-disable-next-line no-restricted-syntax
+export default function() {
+  // Get the selected (front-most) document
+  const document = sketch.getSelectedDocument()
 
-  // Next we want to extract the selected page of the selected (front-most) document
+  // Next we want to extract the selected page of the document
   const page = document.selectedPage
 
   // Now let's create a new text layer, and a traditional value...

--- a/examples/resources/src/resources.js
+++ b/examples/resources/src/resources.js
@@ -6,6 +6,7 @@
 // let's get a hold on the Sketch API
 const sketch = require('sketch')
 
+// eslint-disable-next-line no-restricted-syntax
 export default function(context) {
   // We are going to make a new image layer using the PDF file we included in
   // our Resources folder. To do this, we'll need to fetch the full location
@@ -30,7 +31,8 @@ export default function(context) {
   // These functions all take a single parameter which is a dictionary of properties to set
   // on the new layer. Typically you will want to set the parent of the new layer, its frame, and perhaps
   // some other properties such as its name, style, and so on.
-  const group = new sketch.Group({
+  // eslint-disable-next-line no-new
+  new sketch.Group({
     parent: page,
     frame: {
       x: 0,

--- a/examples/text-utilities/src/text-utilities.js
+++ b/examples/text-utilities/src/text-utilities.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-new */
 // Text Utilities, by Johnnie Walker — Source code available at [GitHub](https://github.com/BohemianCoding/SketchAPI/tree/develop/examples/text-utilities)
 //
 // This plugin provides some debugging tools which annotate text layers to show where their baselines and bounding boxes are.
@@ -49,7 +50,7 @@ function addBaselines(layer, fragments) {
     rect.height = 0.5
 
     // We make a new shape layer with this rectangle.
-    const shape = new sketch.Shape({
+    new sketch.Shape({
       parent: group,
       frame: rect,
       style: {
@@ -79,7 +80,7 @@ function addLineFragments(layer, fragments) {
 
     // We make a new shape layer with the rectangle of each line in turn
     const localRect = layer.localRectToParentRect(fragment.rect)
-    const line = new sketch.Shape({
+    new sketch.Shape({
       parent: group,
       frame: localRect,
       style: {
@@ -136,6 +137,7 @@ export function onUseLegacyBaselines(context) {
   // Iterate over each text layer in the selection, turning off constant baselines.
   document.selectedLayers.forEach(layer => {
     if (layer.type === String(sketch.Types.Text)) {
+      // eslint-disable-next-line no-param-reassign
       layer.lineSpacing = sketch.Text.LineSpacing.variable
     }
   })
@@ -147,6 +149,7 @@ export function onUseConstantBaselines(context) {
   // Iterate over each text layer in the selection, turning on constant baselines.
   document.selectedLayers.forEach(layer => {
     if (layer.type === String(sketch.Types.Text)) {
+      // eslint-disable-next-line no-param-reassign
       layer.lineSpacing = sketch.Text.LineSpacing.constantBaseline
     }
   })


### PR DESCRIPTION
Fix #438 

The reason to disable `no-restricted-syntax` is that because plugins expect an `export default` but I don't want it in the API (and it shares the same eslint config)

The reason to disable `no-new` is because we are not doing anything with the new layers and eslint doesn't like that

The reason to disable `no-param-reassign` is that in this case, that's actually very much what we want to do