### PR TITLE
return undefined when there is no documents

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,8 @@
 {
-  "unreleased": ["[New] Add `isSelected` method on a CurvePoint"],
+  "unreleased": [
+    "[New] Add `isSelected` method on a CurvePoint",
+    "[Fixed] `getSelectedDocument()` could throw an error when no document was opened. Now it will return `undefined`"
+  ],
   "releases": {
     "54": [
       "[New] Add `colors` and `gradients` properties on Document",

--- a/Source/dom/models/Document.js
+++ b/Source/dom/models/Document.js
@@ -43,7 +43,11 @@ export function getSelectedDocument() {
 
   // if there is no current document, let's just try to pick the first one
   if (!nativeDocument) {
-    ;[nativeDocument] = NSApplication.sharedApplication().orderedDocuments()
+    const documents = toArray(
+      NSApplication.sharedApplication().orderedDocuments()
+    ).filter(d => d.isKindOfClass(MSDocument.class()))
+    // eslint-disable-next-line prefer-destructuring
+    nativeDocument = documents[0]
   }
   if (!nativeDocument) {
     return undefined

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "npm run build:test && npm run build:api && node ./scripts/copy-tests.js",
     "build:test": "skpm-test --build-only",
-    "build:api": "webpack -p --optimize-minimize",
+    "build:api": "webpack",
     "start": "npm run build",
     "watch": "webpack --watch",
     "docs:start": "cd docs-website && ./run",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,8 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 const babelLoader = require('@skpm/builder/lib/utils/babelLoader').default({})
 
-const PRODUCTION =
-  process.argv.indexOf('-p') !== -1 || process.env.NODE_ENV === 'production'
+const PRODUCTION = process.env.NODE_ENV !== 'development'
 
 // heuristic to know if we are inside the Sketch repo
 const IS_BC_BUILD = /\/Modules\/SketchAPI$/.test(__dirname)
@@ -33,6 +32,7 @@ babelLoader.test = /\.(ts|js)$/
 babelLoader.use.options.presets.push('@babel/preset-typescript')
 
 const config = {
+  mode: PRODUCTION ? 'production' : 'development',
   resolve: {
     // Add '.ts' as resolvable extensions.
     extensions: ['.ts', '.js', '.json'],


### PR DESCRIPTION
fix #457 

Babel would tranform `[nativeDocument] = NSApplication.sharedApplication().orderedDocuments()` thinking that it's a proper array but it's not, it's an NSArray so it would throw an error.