### PR TITLE
Kevin/fix custom shape type documentation

### DIFF
--- a/docs/api/ShapePath.md
+++ b/docs/api/ShapePath.md
@@ -32,11 +32,11 @@ A shape path layer. It is an instance of [Layer](#layer) so all the methods defi
 ```javascript
 const shapePath = new ShapePath({
   name: 'my shape path',
-  shapePath: ShapePath.ShapeType.Oval,
+  shapeType: ShapePath.ShapeType.Oval,
 })
 ```
 
-You can only set the `shapePath` when creating a new one. Once it is created, the `shapePath` is read-only. If it is not specified, it will default to ShapePath.ShapeType.Rectangle
+You can only set the `shapeType` when creating a new one. Once it is created, the `shapeType` is read-only. If it is not specified, it will default to ShapePath.ShapeType.Rectangle
 
 ```javascript
 const shapePath = ShapePath.fromSVGPath('M10 10 H 90 V 90 H 10 L 10 10')


### PR DESCRIPTION
 I fixed the documentation and attempted to fix the test for `ShapePath` but I’m a little confused with the eslint constraint with enforcing property shorthands. When I copy the code into the Script Panel the shapePath object isn’t created. Perhaps the tests get compiled into something that Sketch can properly execute.

I am also a little confused about this comment under `ShapePath.js`

```
const ShapeTypeMapReverse = {
  Rectangle: MSRectangleShape,
  Oval: MSOvalShape,
  Polygon: MSPolygonShape,
  Star: MSStarShape,
  Triangle: MSTriangleShape,
  Custom: MSRectangleShape, // we are just going to default to Rectangle here
}
```
This seems to be the root of the problem. Why isn’t `Custom` mapped to `MSShapePathLayer`? This means you can’t create lines programmatically in the same way that you can with the line tool.

This PR needs more work but hopefully its helpful in pointing out the areas of issues.