### PR TITLE
change NSCombobox to a NSPopUpButton

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -161,6 +161,7 @@ globals:
   CGPathGetBoundingBox: false
   MSShapeEventHandler: false
   NSIndexPath: false
+  NSPopUpButton: false
 
 rules:
   ###########

--- a/Source/ui/UI.js
+++ b/Source/ui/UI.js
@@ -138,11 +138,10 @@ export function getInputFromUser(messageText, options, callback) {
           'When the input type is `selection`, you need to provide the array of possible choices.'
         )
       }
-      accessory = NSComboBox.alloc().initWithFrame(NSMakeRect(0, 0, 295, 25))
-      accessory.addItemsWithObjectValues(options.possibleValues)
+      accessory = NSPopUpButton.alloc().initWithFrame(NSMakeRect(0, 0, 295, 25))
+      accessory.addItemsWithTitles(options.possibleValues)
       const initialIndex = options.possibleValues.indexOf(options.initialValue)
       accessory.selectItemAtIndex(initialIndex !== -1 ? initialIndex : 0)
-      accessory.editable = false
       break
     }
     default:


### PR DESCRIPTION
Fixes #315 

I thought it was a little strange to use a `NSCombobox` for this dropdown. That being said, the `NSComboBox` is a bit more useful if you have tons of things to select from.