### PR TITLE
Remove case of API being built as submodule

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,13 +4,7 @@ const babelLoader = require('@skpm/builder/lib/utils/babelLoader').default({})
 
 const PRODUCTION = process.env.NODE_ENV !== 'development'
 
-// heuristic to know if we are inside the Sketch repo
-const IS_BC_BUILD = /\/Modules\/SketchAPI$/.test(__dirname)
-
-const OUTPUT_PATH = path.resolve(
-  __dirname,
-  IS_BC_BUILD ? '../SketchPluginManager/Source/api/' : './build'
-)
+const OUTPUT_PATH = path.resolve(__dirname, './build')
 
 const ENTRIES = [
   { entry: './Source/index.ts', output: 'SketchAPI.js' },


### PR DESCRIPTION
Ref #513 

Build artefacts are always saved to the build folder in the API repo.

Now that Jenkins uses the same `npm run build` to produce the zipped API bundle, including the API and core modules, this case of building the API in the context of a submodule within the Sketch repo is no longer relevant.