### PR TITLE
Fix for fromSVGPath()

### DIFF
--- a/Source/dom/layers/ShapePath.js
+++ b/Source/dom/layers/ShapePath.js
@@ -78,14 +78,10 @@ export class ShapePath extends StyledLayer {
   }
 
   static fromSVGPath(svgPath) {
-    const closed = MOPointer.alloc().init()
     return new this({
       sketchObject: MSShapePathLayer.layerWithPath(
         MSPath.pathWithBezierPath(
-          SVGPathInterpreter.bezierPathFromCommands_isPathClosed(
-            svgPath,
-            closed
-          )
+          SVGPathInterpreter.bezierPathFromCommands(svgPath)
         )
       ),
     })


### PR DESCRIPTION
Closes BohemianCoding/Sketch#26272

The internal method we use was renamed in 58. The tests were not passing, and now they are, so the fix does not change the tests