### PR TITLE
Release/58.1

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [],
   "releases": {
+    "58.1": ["[Fixed] `ShapePath.fromSVGPath` no longer throws an error"],
     "57": [
       "[New] Expose the `PointType` enum on `ShapePath`",
       "[Fixed] `document.centerOnLayer` not centering on nested layers"


### PR DESCRIPTION
Merge this back to `develop` once incorporated into `Sketch/release/58.1`

Changes/fixes:

- `fromSVGPath` bug https://github.com/BohemianCoding/Sketch/issues/26272