### PR TITLE
Tighten the spacing for code blocks

### DIFF
--- a/docs-website/_sass/helpers/_helpers.scss
+++ b/docs-website/_sass/helpers/_helpers.scss
@@ -275,6 +275,5 @@ a:focus > .link-heading-arrow::after {
 }
 
 .highlighter-rouge {
-  margin-top: 1rem !important;
-  margin-bottom: 3rem !important;
+  margin-bottom: 1rem !important;
 }


### PR DESCRIPTION
This removes a weird space under code blocks that made text pages looks a bit silly.